### PR TITLE
Json failmsg devices controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,15 @@ class ApplicationController < ActionController::Base
     @from_copo_app ||= request.headers["X-Secret-App-Key"] == Rails.application.secrets.mobile_app_key
   end
 
+  def invalid_payload(msg, redirect_path)
+    if req_from_coposition_app?
+      render status: 400, json: { message: msg }
+    else
+      flash[:alert] = msg
+      redirect_to redirect_path
+    end
+  end
+
 
   protected
 

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -34,10 +34,10 @@ class Users::DevicesController < ApplicationController
         create_device
         redirect_using_param_or_default unless via_app
       else
-        invalid_uuid 'This device has already been assigned to a user'
+        invalid_payload('This device has already been assigned to a user', new_user_device_path)
       end
     else
-      invalid_uuid 'The UUID provided does not match an existing device'
+      invalid_payload('The UUID provided does not match an existing device', new_user_device_path)
     end
   end
 
@@ -117,12 +117,4 @@ class Users::DevicesController < ApplicationController
       end
     end
 
-    def invalid_uuid(msg)
-      if req_from_coposition_app?
-        render status: 400, json: { message: msg }
-      else
-        flash[:alert] = msg
-        redirect_to new_user_device_path
-      end
-    end
 end

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -34,13 +34,19 @@ class Users::DevicesController < ApplicationController
       if @device.user.nil?
         create_device
         redirect_using_param_or_default unless via_app
+      elsif req_from_coposition_app?
+        render status: 400, json: { message: 'This device has already been assigned to a user' }
       else
         flash[:alert] = "This device has already been assigned an account!"
         redirect_to new_user_device_path
       end
     else
-      flash[:alert] = "Not found"
-      redirect_to new_user_device_path
+      if req_from_coposition_app?
+        render status: 400, json: { message: 'The UUID provided does not match an existing device' }
+      else
+        flash[:alert] = "Not found"
+        redirect_to new_user_device_path
+      end
     end
   end
 


### PR DESCRIPTION
Could add more arguments to invalid_payload such as status but not sure if necessary, also searched through codebase for any other places where this could be used, Sessions controller does render some json messages but it's always reqs from coposition app so this method would not really help.