### PR TITLE
Changed Create in Devices Controller

### DIFF
--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -28,7 +28,11 @@ class Users::DevicesController < ApplicationController
   end
 
   def create
-    @device = Device.find_by uuid: allowed_params[:uuid]
+    if allowed_params[:uuid]
+      @device = Device.find_by uuid: allowed_params[:uuid]
+    else
+      @device = Device.create
+    end
     if @device
       # Providing that there isn't anyone currently assigned
       if @device.user.nil?

--- a/spec/controllers/users/devices_controller_spec.rb
+++ b/spec/controllers/users/devices_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Users::DevicesController, type: :controller do
     expect(subject.current_user).to_not be nil
   end
 
-  let(:empty_device) { Device.create }
   let(:device) { FactoryGirl::create :device }
   let(:user) { User.last }
 
@@ -22,12 +21,11 @@ RSpec.describe Users::DevicesController, type: :controller do
       # For some reason, subject.current user was returning some weird results. Using last User instead
       post :create, {
       	user_id: user.username,
-      	device: { uuid: empty_device.uuid }
+      	device: { uuid: device.uuid }
       }
-      
       expect(response.code).to eq "302"
       expect(user.devices.count).to be 1
-      expect(user.devices.last).to eq empty_device
+      expect(user.devices.last).to eq device
     end
 
     it "should switch fogging status to true by default" do


### PR DESCRIPTION
Previously to use the API you had to make a get request to https://api.coposition.com/v1/uuid in order to get a UUID, this request created a new empty device. You then used this UUID to link a device to a user etc.
This change removes the need for this step, you can still submit a UUID for an existing device if you wish but if no UUID is sent then a new device is created and assigned to you. This makes more sense to me but not sure if I am missing something.
Also changed the test for the create POST request as as far as I could see "empty_device" was exactly the same as "device", it just didn't have a name, which shouldn't make a difference in what the test is testing anyway.