### PR TITLE
Changed device create so that uuid is not required before create

### DIFF
--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -28,7 +28,11 @@ class Users::DevicesController < ApplicationController
   end
 
   def create
-    @device = Device.find_by uuid: allowed_params[:uuid]
+    if allowed_params[:uuid]
+      @device = Device.find_by uuid: allowed_params[:uuid]
+    else
+      @device = Device.create
+    end
     if @device
       if @device.user.nil?
         create_device


### PR DESCRIPTION
A uuid can still be submitted with the post request which needs to be associated with an existing device, if no uuid is submitted, a new empty device is created (which gets assigned a uuid due to the before create block in the device model.)