### PR TITLE
Api pagination

### DIFF
--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
   before_action :authenticate, :check_user_approved_developer, :find_device, :check_privilege
 
   def index
-    checkins = @device.checkins.order('created_at DESC').paginate(page: params[:page], per_page: 10)
+    checkins = @device.checkins.order('created_at DESC').paginate(page: params[:page], per_page: 30)
     response['Current-Page'] = checkins.current_page.to_json
     response['Next-Page'] = checkins.next_page.to_json
     response['Total-Entries'] = checkins.total_entries.to_json

--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -4,11 +4,13 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
   before_action :authenticate, :check_user_approved_developer, :find_device, :check_privilege
 
   def index
-    checkins = @device.checkins.all
+    checkins = @device.checkins.order('created_at DESC').paginate(page: params[:page], per_page: 10)
+    response.headers['Current-Page'] = checkins.current_page.to_json
+    response.headers['Total-Entries'] = checkins.total_entries.to_json
+    response.headers['Per-Page'] = checkins.per_page.to_json
     checkins = checkins.map do |checkin|
       resolve checkin
     end
-
     render json: checkins.to_json
   end
 

--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
   def index
     checkins = @device.checkins.order('created_at DESC').paginate(page: params[:page], per_page: 10)
     response['Current-Page'] = checkins.current_page.to_json
+    response['Next-Page'] = checkins.next_page.to_json
     response['Total-Entries'] = checkins.total_entries.to_json
     response['Per-Page'] = checkins.per_page.to_json
     checkins = checkins.map do |checkin|

--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -5,9 +5,9 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
 
   def index
     checkins = @device.checkins.order('created_at DESC').paginate(page: params[:page], per_page: 10)
-    response.headers['Current-Page'] = checkins.current_page.to_json
-    response.headers['Total-Entries'] = checkins.total_entries.to_json
-    response.headers['Per-Page'] = checkins.per_page.to_json
+    response['Current-Page'] = checkins.current_page.to_json
+    response['Total-Entries'] = checkins.total_entries.to_json
+    response['Per-Page'] = checkins.per_page.to_json
     checkins = checkins.map do |checkin|
       resolve checkin
     end

--- a/app/views/users/devices/_checkin_table.html.erb
+++ b/app/views/users/devices/_checkin_table.html.erb
@@ -35,5 +35,5 @@
       </td>
     </tr>  
   <% end %>
-  <%= will_paginate @checkins %>
 </table>
+<%= will_paginate @checkins %>


### PR DESCRIPTION
Checkins passed using the API index action will now be paginated (10 per page), in the headers of the response are the current page, next page, total entries, and number of entries per page. 
Also moved pagination in checkin_table view to end of file so that search index bar thing is in the right place.