### PR TITLE
Copied checkin creation to the other checkins controller

### DIFF
--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -27,4 +27,19 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
     end
   end
 
+  def create
+    checkin = Checkin.create(allowed_params)
+    if checkin.id
+      render json: checkin.to_json
+    else
+      render status: 400, json: { message: 'You must provide a UUID, lat and lng' }
+    end
+  end
+
+  private
+
+  def allowed_params
+    params.require(:checkin).permit(:uuid, :lat, :lng)
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
           end
         end
         resources :devices, only: [:index, :show], module: :users do
-          resources :checkins, only: [:index], module: :devices do
+          resources :checkins, only: [:index, :create], module: :devices do
             collection do
               get :last
             end


### PR DESCRIPTION
Now checkin's creation will require an API key/consume credit. Left the original route intact for now so we can still test the android app.