### PR TITLE
Don't overwrite checkins with fogged data

### DIFF
--- a/app/controllers/api/v1/users/devices/checkins_controller.rb
+++ b/app/controllers/api/v1/users/devices/checkins_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Users::Devices::CheckinsController < Api::ApiController
         checkin.reverse_geocode!
         checkin.get_data
     else
-      checkin.slice(:id, :uuid, :lat, :lng,:created_at)
+      checkin.slice(:id, :uuid, :lat, :lng, :created_at)
     end
   end
 

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -23,13 +23,16 @@ class Checkin < ActiveRecord::Base
 
   # The method to be used for public-facing data 
   def get_data
+    binding.pry
+    fogged_checkin = self
     if device.fogged?
-      self.lat = nearest_city.latitude
-      self.lng = nearest_city.longitude
-      self.address = "#{city}, #{country_code}"
+      fogged_checkin.lat = nearest_city.latitude
+      fogged_checkin.lng = nearest_city.longitude
+      fogged_checkin.address = "#{city}, #{country_code}"
+      fogged_checkin
+    else
+      self
     end
-
-    self
   end
 
   def reverse_geocode!

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -23,7 +23,6 @@ class Checkin < ActiveRecord::Base
 
   # The method to be used for public-facing data 
   def get_data
-    binding.pry
     fogged_checkin = self
     if device.fogged?
       fogged_checkin.lat = nearest_city.latitude


### PR DESCRIPTION
Previously when you requested a checkin from a fogged device, the originally checkin was overwritten with the fogged data. Changed it so the fogged data is returned but the original checkin is unchanged for future use.