### PR TITLE
Changed simple token authentication to use email rather than username

### DIFF
--- a/config/initializers/simple_token_authentication.rb
+++ b/config/initializers/simple_token_authentication.rb
@@ -33,7 +33,7 @@ SimpleTokenAuthentication.configure do |config|
   #   Then both the header names identifier key and default value are modified accordingly:
   #     `config.header_names = { super_admin: { phone_number: 'X-SuperAdmin-PhoneNumber' } }`
   #
-  config.header_names = { user: { authentication_token: 'X-User-Token', username: 'X-User-Username' } }
+  config.header_names = { user: { authentication_token: 'X-User-Token', email: 'X-User-Email' } }
 
   # Configure the name of the attribute used to identify the user for authentication.
   # That attribute must exist in your model.
@@ -51,7 +51,7 @@ SimpleTokenAuthentication.configure do |config|
   #
   #   `config.identifiers = { super_admin: 'phone_number', user: 'uuid' }`
   #
-  config.identifiers = { user: 'username' }
+  config.identifiers = { user: 'email' }
 
   # Configure the Devise trackable strategy integration.
   #

--- a/spec/controllers/users/devices_controller_spec.rb
+++ b/spec/controllers/users/devices_controller_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Users::DevicesController, type: :controller do
       headers = {
         "X-Api-Key" => developer.api_key,
         "X-User-Token" => user.authentication_token,
-        "X-User-Username" => user.username,
+        "X-User-Email" => user.email,
         "X-Secret-App-Key" => Rails.application.secrets.mobile_app_key
       }
       post "/users/#{user.username}/devices", {
@@ -310,7 +310,7 @@ RSpec.describe Users::DevicesController, type: :controller do
       headers = {
         "X-Api-Key" => developer.api_key,
         "X-User-Token" => user.authentication_token,
-        "X-User-Username" => user.username,
+        "X-User-Email" => user.email,
         "X-Secret-App-Key" => Rails.application.secrets.mobile_app_key
       }
       post "/users/#{user.username}/devices", {


### PR DESCRIPTION
Assuming APP in it's current state still sends auth token + username so we can let them know about this change along with all the other new stuff we're gonna ask of them.