### PR TITLE
Api resource missing

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -43,4 +43,21 @@ class Api::ApiController < ActionController::Base
     request.headers['X-User-Token'] == auth_token
   end
 
+  def method_missing(method_sym, *arguments, &block)
+    method_string = method_sym.to_s
+    if /(?<resource>[\w]+)_exists\?$/ =~ method_string
+      resource_exists?(resource, arguments[0])
+    else
+      super
+    end
+  end
+
+  def resource_exists?(resource, arguments)
+    model = resource.titleize.constantize
+    unless arguments
+      render status: 404, json: { message: "#{model} does not exist" }
+    end
+    arguments
+  end
+
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -54,9 +54,7 @@ class Api::ApiController < ActionController::Base
 
   def resource_exists?(resource, arguments)
     model = resource.titleize.constantize
-    unless arguments
-      render status: 404, json: { message: "#{model} does not exist" }
-    end
+    render status: 404, json: { message: "#{model} does not exist" } unless arguments
     arguments
   end
 

--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -14,12 +14,10 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
 
   def update
     approval = Approval.where(id: params[:id], user: @user).first
-    if approval
+    if approval_exists? approval
       approval.update(allowed_params)
       @user.approve_devices_for_developer(@dev) if allowed_params[:approved]
       render json: approval
-    else
-      render status: 400, json: { message: 'Approval does not exist/belong to user' }
     end
   end
 

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -39,12 +39,9 @@ class Api::V1::Users::DevicesController < Api::ApiController
   def switch_privilege_for_developer
     device = @user.devices.where(id: params[:id]).first
     developer = Developer.where(id: params[:developer_id]).first
-    if device && developer
+    if (device_exists? device) && (developer_exists? developer)
       device.change_privilege_for(developer, device.reverse_privilege_for(developer))
-      device.reverse_privilege_for(developer)
       render status: 200, json: device.device_developer_privileges.where(developer: developer)
-    else
-      render status: 404, json: { message: 'Device/Developer not found' }
     end
   end
 
@@ -52,15 +49,12 @@ class Api::V1::Users::DevicesController < Api::ApiController
     devices = @user.devices
     developer = Developer.where(id: params[:developer_id]).first
     privileges = []
-    if devices && developer
+    if (device_exists? devices) && (developer_exists? developer)
       devices.each do |device|
         device.change_privilege_for(developer, device.reverse_privilege_for(developer))
-        device.reverse_privilege_for(developer)
         privileges << device.device_developer_privileges.where(developer: developer)
       end
       render status: 200, json: privileges
-    else
-      render status: 404, json: { message: 'Device/Developer not found' }
     end
   end
 

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -26,11 +26,10 @@ class Api::V1::Users::DevicesController < Api::ApiController
   end
 
   def update
-    if device = @user.devices.where(id: params[:id]).first
+    device = @user.devices.where(id: params[:id]).first
+    if device_exists? device
       device.update(device_params)
       render json: device
-    else
-      render status: 400, json: { message: 'Device does not exist' }
     end
   end
 

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
         },
         format: :json
       }
-      expect(response.status).to be 400
+      expect(response.status).to be 404
       expect(user.approved_developer? developer).to be false
     end
 

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
 
     it "should reject non-existant device ids" do
       put :update, { user_id: user.id, id: 999999999,  device: { fogged: true }, format: :json }
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(404)
       expect(res_hash[:message]).to eq('Device does not exist')
     end
 

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   describe "POST" do
 
     it 'should change privilege for developer on a device' do
-      priv = device.device_developer_privileges.where(developer: developer).first
+      expect(device.privilege_for(developer)).to eq 'complete'
       post :switch_privilege_for_developer, {
         developer_id: developer.id,
         user_id: user.username,
@@ -87,18 +87,18 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
         format: :json
       }
       expect(response.status).to be 200
-      expect(res_hash.first['privilege']).to_not eq priv.privilege
+      expect(device.privilege_for(developer)).to eq 'disallowed'
     end
 
     it 'should change privilege for developer on all devices' do
-      priv = device.device_developer_privileges.where(developer: developer).first
+      expect(user.devices.last.privilege_for(developer)).to eq 'complete'
       post :switch_all_privileges_for_developer, {
         developer_id: developer.id,
         user_id: user.username,
         format: :json
       }
-      expect(res_hash.first.first['privilege']).to_not eq priv.privilege
       expect(response.status).to be 200
+      expect(user.devices.last.privilege_for(developer)).to eq 'disallowed'
     end
 
     it 'should not change privilege for developer if user not signed in user' do
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
         user_id: user.username,
         format: :json
       }
-      expect(res_hash[:message]).to eq 'Device/Developer not found'
+      expect(res_hash[:message]).to eq 'Device does not exist'
       expect(response.status).to be 404
     end
   end


### PR DESCRIPTION
Added a resource_missing method to dry up some code from device_controller/approvals controller. Simply returns a 404 message with the name of the model of the resource that is missing.