### PR TITLE
Fixed User being left on copo

### DIFF
--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -6,7 +6,11 @@ class Users::ApprovalsController < ApplicationController
   def index
     @approved_devs = current_user.approved_developers
     @pending_approvals = current_user.pending_approvals
-    if @pending_approvals.length == 0 && params[:redirect]
+    if @approved_devs.length == 0 && @pending_approvals.length == 0 && params[:redirect]
+      developer = Developer.find_by(api_key: params[:api_key])
+      developer.request_approval_from current_user
+      @pending_approvals = current_user.pending_approvals
+    elsif @pending_approvals.length == 0 && params[:redirect]
       redirect_to params[:redirect]
     end
   end


### PR DESCRIPTION
Previously if a user tried to link with coposition before they had an account, no approval was created after they had signed up on coposition. Now an approval is created and can be approved after sign up and the user is then redirected to the app the approval came from.