### PR TITLE
Approvals refactor

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -47,6 +47,10 @@ class Api::ApiController < ActionController::Base
   def find_device
     @device = Device.find(params[:device_id])
   end
+
+  def model_find(type)
+    [User, Developer].find { |model| model.name == type.titleize}
+  end
   
   def check_privilege
     unless @device.privilege_for(@dev) == "complete"

--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
   before_action :check_user, only: :update
 
   def create
-    @dev.request_approval_from(@user).select(:id, :status).first
+    Approval.link(@user.id, @dev.id, 'Developer')
     approval = Approval.where(user: @user, approvable_id: @dev.id, approvable_type: 'Developer')
     render json: approval
   end

--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
   before_action :check_user, only: :update
 
   def create
-    Approval.link(@user.id, @dev.id, 'Developer')
+    Approval.link(@user, @dev, 'Developer')
     approval = Approval.where(user: @user, approvable_id: @dev.id, approvable_type: 'Developer')
     render json: approval
   end

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
   end
 
   def switch_privilege
-    model = [User, Developer].find { |x| x.name == params[:permissible_type]}
+    model = model_find(params[:permissible_type])
     @permissible = model.where(id: params[:permissible_id]).first
     device = @user.devices.where(id: params[:id]).first
     if (device_exists? device) && (resource_exists?(params[:permissible_type], @permissible))
@@ -47,7 +47,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
   end
 
   def switch_all_privileges
-    model = [User, Developer].find { |x| x.name == params[:permissible_type]}
+    model = model_find(params[:permissible_type])
     @permissible = model.where(id: params[:permissible_id]).first
     devices = @user.devices
     permissions = []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
     current_user == User.find(user_id)
   end
 
+  def model_find(type)
+    [User, Developer].find { |model| model.name == type.titleize}
+  end
+
   protected
 
     def actor_owns_resource?(actor, resource, id)

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -13,7 +13,7 @@ class Developers::ApprovalsController < ApplicationController
 
   def create
     user = User.find_by(email: allowed_params[:user])
-    if Approval.link(user.id, current_developer.id, 'Developer')
+    if Approval.link(user, current_developer, 'Developer')
       flash[:notice] = "Successfully sent" 
     else
       flash[:alert] = "Approval request already sent"

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -12,7 +12,8 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def create
-    if current_developer.request_approval_from User.find_by(email: allowed_params["user"])
+    user = User.find_by(email: allowed_params[:user])
+    if Approval.link(user.id, current_developer.id, 'Developer')
       flash[:notice] = "Successfully sent" 
     else
       flash[:alert] = "Approval request already sent"

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -9,17 +9,13 @@ class Users::ApprovalsController < ApplicationController
 
   def create
     model = [User, Developer].find { |x| x.name == allowed_params[:approvable_type].titleize}
-    @approvable = model.find_by(email: allowed_params[:user])
+    @approvable = model.find_by(email: allowed_params[:approvable])
     if @approvable
-      if current_user.friend_requests.include?(@approvable)
-        Approval.accept(current_user.id, @approvable.id, 'User')
-        flash[:notice] = "Friend added."
-      elsif @approvable.class.to_s == 'Developer'
-        current_user.link_with(@approvable) unless current_user.approve_developer(@approvable)
-        flash[:notice] = "Developer added."
-      else
-        Approval.link(current_user.id, @approvable.id, 'User')
-        flash[:alert] = "Friend request sent."
+      Approval.link(current_user.id, @approvable.id, allowed_params[:approvable_type])
+      flash[:notice] = "Request sent"
+      if (allowed_params[:approvable_type] == 'Developer') || (current_user.friend_requests.include?(@approvable))
+        Approval.accept(current_user.id, @approvable.id, allowed_params[:approvable_type])
+        flash[:notice] = "User/Developer added!"
       end
       redirect_to user_approvals_path
     else
@@ -73,7 +69,7 @@ class Users::ApprovalsController < ApplicationController
     end
 
     def allowed_params
-      params.require(:approval).permit(:user, :approvable_type)
+      params.require(:approval).permit(:approvable, :approvable_type)
     end
 
 end

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -42,15 +42,24 @@ class Users::ApprovalsController < ApplicationController
   def approve
     @approval = Approval.where(id: params[:id], 
       user: current_user).first
-    @approval.approve!
+    Approval.accept(current_user, @approval.approvable, @approval.approvable_type)
     @approved_devs = current_user.developers
+    @friends = current_user.friends
+    @friend_requests = current_user.friend_requests
+    @pending_friends = current_user.pending_friends
   end
 
   def reject
     @approval = Approval.where(id: params[:id], 
       user: current_user).first
+    if @approval.approvable_type == 'User'
+      Approval.where(user: @approval.approvable, approvable: @approval.user, approvable_type: 'User').first.destroy
+    end
     @approval.destroy
     @approved_devs = current_user.developers
+    @friends = current_user.friends
+    @friend_requests = current_user.friend_requests
+    @pending_friends = current_user.pending_friends
     render "users/approvals/approve"
   end
 

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -13,9 +13,9 @@ class Users::ApprovalsController < ApplicationController
     approvable = model.find_by(email: allowed_params[:approvable])
     if approvable
       flash[:notice] = "Approval already exists"
-      flash[:notice] = "Request sent" if Approval.link(current_user.id, approvable.id, type)
+      flash[:notice] = "Request sent" if Approval.link(current_user, approvable, type)
       if (type == 'Developer') || (current_user.friend_requests.include?(approvable))
-        flash[:notice] = "User/Developer added!" if Approval.accept(current_user.id, approvable.id, type)
+        flash[:notice] = "User/Developer added!" if Approval.accept(current_user, approvable, type)
       end
       redirect_to user_approvals_path
     else
@@ -32,7 +32,7 @@ class Users::ApprovalsController < ApplicationController
     # Redirect if foreign app failed to create a pending approval.
     if @approved_devs.length == 0 && @pending_approvals.length == 0 && params[:redirect]
       developer = Developer.find_by(api_key: params[:api_key])
-      Approval.link(current_user.id, developer.id, 'Developer')
+      Approval.link(current_user, developer, 'Developer')
       @pending_approvals = current_user.pending_approvals
     elsif @pending_approvals.length == 0 && params[:redirect]
       redirect_to params[:redirect]

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -9,7 +9,7 @@ class Users::ApprovalsController < ApplicationController
 
   def create
     type = allowed_params[:approvable_type]
-    model = [User, Developer].find { |x| x.name == type.titleize}
+    model = model_find(type)
     approvable = model.find_by(email: allowed_params[:approvable])
     if approvable
       flash[:notice] = "Approval already exists"

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -60,7 +60,7 @@ class Users::DevicesController < ApplicationController
   end
 
   def switch_privilege
-    model = [User, Developer].find { |x| x.name == params[:permissible_type]}
+    model = model_find(params[:permissible_type])
     @permissible = model.find(params[:permissible])
     @device = Device.find(params[:id])
     @device.change_privilege_for(@permissible, params[:privilege])
@@ -70,7 +70,7 @@ class Users::DevicesController < ApplicationController
   end
 
   def switch_all_privileges
-    model = [User, Developer].find { |x| x.name == params[:permissible_type]}
+    model = model_find(params[:permissible_type])
     @devices = current_user.devices
     @permissible = model.find(params[:permissible])
     @devices.each do |device|

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -6,29 +6,29 @@ class Approval < ActiveRecord::Base
   before_create do
     not_self = true
     if approvable_type == 'User'
-      not_self = (user_id != approvable_id)
+      not_self = (user != approvable)
     end
-    not_self && !Approval.exists?(user_id: user_id, approvable_id: approvable_id, approvable_type: approvable_type)
+    not_self && !Approval.exists?(user: user, approvable: approvable, approvable_type: approvable_type)
   end
 
-  def self.link(user_id, approvable_id, approvable_type)
+  def self.link(user, approvable, approvable_type)
     if approvable_type == 'Developer'
-      Approval.create(:user_id => user_id, :approvable_id => approvable_id, :approvable_type => approvable_type, :status => 'developer-requested' )
+      Approval.create(user: user, approvable: approvable, approvable_type: approvable_type, status: 'developer-requested' )
     else
-      Approval.create(:user_id => user_id, :approvable_id => approvable_id, :approvable_type => approvable_type, :status => 'pending' )
-      Approval.create(:user_id => approvable_id, :approvable_id => user_id, :approvable_type => approvable_type, :status => 'requested' )
+      Approval.create(user: user, approvable: approvable, approvable_type: approvable_type, status: 'pending' )
+      Approval.create(user: approvable, approvable: user, approvable_type: approvable_type, status: 'requested' )
     end
   end
 
-  def self.accept(user_id, approvable_id, approvable_type)
+  def self.accept(user, approvable, approvable_type)
     transaction do
-      accept_one_side(user_id, approvable_id, approvable_type)
-      accept_one_side(approvable_id, user_id, approvable_type) unless approvable_type == 'Developer'
+      accept_one_side(user, approvable, approvable_type)
+      accept_one_side(approvable, user, approvable_type) unless approvable_type == 'Developer'
     end
   end
 
-  def self.accept_one_side(user_id, approvable_id, approvable_type)
-    request = find_by_user_id_and_approvable_id_and_approvable_type(user_id, approvable_id, approvable_type)
+  def self.accept_one_side(user, approvable, approvable_type)
+    request = find_by_user_id_and_approvable_id_and_approvable_type(user.id, approvable.id, approvable_type)
     request.approve!
     request.save!
   end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -12,8 +12,12 @@ class Approval < ActiveRecord::Base
   end
 
   def self.link(user_id, approvable_id, approvable_type)
-    Approval.create(:user_id => user_id, :approvable_id => approvable_id, :approvable_type => approvable_type, :status => 'pending' )
-    Approval.create(:user_id => approvable_id, :approvable_id => user_id, :approvable_type => approvable_type, :status => 'requested' ) unless approvable_type == 'Developer'
+    if approvable_type == 'Developer'
+      Approval.create(:user_id => user_id, :approvable_id => approvable_id, :approvable_type => approvable_type, :status => 'developer-requested' )
+    else
+      Approval.create(:user_id => user_id, :approvable_id => approvable_id, :approvable_type => approvable_type, :status => 'pending' )
+      Approval.create(:user_id => approvable_id, :approvable_id => user_id, :approvable_type => approvable_type, :status => 'requested' )
+    end
   end
 
   def self.accept(user_id, approvable_id, approvable_type)

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -22,10 +22,6 @@ class Developer < ActiveRecord::Base
     dev.api_key = SecureRandom.uuid
   end
 
-  def request_approval_from(user)
-    approvals << Approval.create(user_id: user.id, approvable_id: self.id, approvable_type: 'Developer', status: 'developer-requested')
-  end
-
   def slack_message
     "A new developer has registered, there are now #{Developer.count} developers."
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,26 +36,9 @@ class User < ActiveRecord::Base
 
   ## Approvals
 
-  def link_with(developer)
-    approvals << Approval.create(user_id: self.id, approvable_id: developer.id, approvable_type: 'Developer', status: 'accepted')
-    approvals.last.approve!
-  end
-
-  def approve_developer(developer)
-    app = approvals.where(status: 'developer-requested', approvable_id: developer.id).first
-    unless app
-      return false
-    end
-    app.approve!
-  end
-
   def approved_developer?(dev)
-    app = approvals.where(approvable_id: dev.id, approvable_type: 'Developer').first
-    app && app.status == 'accepted'
+    developers.include? dev
   end
-
-  ##############
-
 
   ## Devices
 
@@ -73,7 +56,7 @@ class User < ActiveRecord::Base
 
   ################
 
-  ## Metadata
+  ## Checkins
 
   def last_checkin
     checkins.sort_by(&:created_at).last

--- a/app/views/users/approvals/_friend_requests.html.erb
+++ b/app/views/users/approvals/_friend_requests.html.erb
@@ -1,15 +1,19 @@
 <% if @friend_requests %>
 
-You have <%= @friend_requests.length %> friend requests and <%= @pending_friends.length %> pending friends.
 <div class='list-group'>
   <% @friend_requests.each do |friend| %>
     <div class='list-group-item'>
-      <h5 class='list-group-item-heading'><%= friend.email %></h5>
-      <%= form_for Approval.new, url: user_approvals_path, class: "form-group" do |f| %>
-        <%= f.hidden_field :approvable, value: friend.email, class: "form-control input-lg fifth-width" %><br />
-        <%= f.hidden_field :approvable_type, value: 'User', class: "form-control input-lg fifth-width" %><br />
-        <%= f.submit("Accept", class: "form-control btn btn-default") %>
-      <% end %>
+      <% app = current_user.approvals.where(approvable: friend).first %>
+      <div id="<%= "app_#{app.id}" %>"class="panel panel-default m-m third-width animated flipInY">
+        <div class="panel-heading">
+          <h4><%= User.find(app.approvable_id).email %></h4>
+        </div>
+        <div class="panel-body input-group">
+          <%= button_to "Accept", approve_user_approval_path(current_user.url_id, app.id), remote: true, class: "btn btn-success m-m" %>
+          <%= button_to "Reject", reject_user_approval_path(current_user.url_id, app.id), remote: true, class: "btn btn-danger" %>
+        </div>
+        <br>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/users/approvals/_friend_requests.html.erb
+++ b/app/views/users/approvals/_friend_requests.html.erb
@@ -6,7 +6,7 @@ You have <%= @friend_requests.length %> friend requests and <%= @pending_friends
     <div class='list-group-item'>
       <h5 class='list-group-item-heading'><%= friend.email %></h5>
       <%= form_for Approval.new, url: user_approvals_path, class: "form-group" do |f| %>
-        <%= f.hidden_field :user, value: friend.email, class: "form-control input-lg fifth-width" %><br />
+        <%= f.hidden_field :approvable, value: friend.email, class: "form-control input-lg fifth-width" %><br />
         <%= f.hidden_field :approvable_type, value: 'User', class: "form-control input-lg fifth-width" %><br />
         <%= f.submit("Accept", class: "form-control btn btn-default") %>
       <% end %>

--- a/app/views/users/approvals/_friends.html.erb
+++ b/app/views/users/approvals/_friends.html.erb
@@ -1,3 +1,5 @@
+You have <%= @friend_requests.length %> friend requests and <%= @pending_friends.length %> pending friends.
+
 <div class='list-group'>
   <% @friends.each do |friend| %>
     <div class='list-group-item'>

--- a/app/views/users/approvals/_pending_approvals.html.erb
+++ b/app/views/users/approvals/_pending_approvals.html.erb
@@ -1,8 +1,5 @@
 <% if @pending_approvals %>
 
-  You have
-  <span id="pending_count"><%= @pending_approvals.length %></span>
-  pending.
   <br>
   <% @pending_approvals.each do |app| %>
     <div id="<%= "app_#{app.id}" %>"class="panel panel-default m-m third-width animated flipInY">

--- a/app/views/users/approvals/approve.js.erb
+++ b/app/views/users/approvals/approve.js.erb
@@ -1,8 +1,7 @@
 if (utility.urlParam("redirect")) {
   window.location.replace(utility.urlParam("redirect"));
 }
-var pen = $("#pending_count");
-pen.html(parseInt(pen.html()) - 1);
 $("#<%= "app_#{@approval.id}" %>").addClass("bg-approved-<%= @approval.status == 'accepted' %>");
 utility.animations.removeEl($("#<%= "app_#{@approval.id}" %>"));
 $('#approvedDevelopers').html("<%= (render partial: 'approved_developers').delete("\n").html_safe %>").addClass("rubberBand")
+$('#friends').html("<%= (render partial: 'friends').delete("\n").html_safe %>").addClass("rubberBand")

--- a/app/views/users/approvals/index.html.erb
+++ b/app/views/users/approvals/index.html.erb
@@ -6,6 +6,8 @@
   <%= render partial: "approved_developers" %>
 </div>
 <h3 class="m-m">Friends</h3>
-<%= render partial: "friends" %>
+<div id="friends" class="animated">
+  <%= render partial: "friends" %>
+</div>
 <%= render partial: "friend_requests" %>
 

--- a/app/views/users/approvals/new.html.erb
+++ b/app/views/users/approvals/new.html.erb
@@ -3,8 +3,8 @@ Enter the email address of a registered user or developer so that you can ask fo
 <%= form_for @approval, url: user_approvals_path do |f| %>
   <div class="row">
     <div class="input-field col s12">
-      <%= f.label :user, 'Email', class: "active" %>
-      <%= f.email_field :user, placeholder: "email@email.com", class: "validate" %>
+      <%= f.label :approvable, 'Email', class: "active" %>
+      <%= f.email_field :approvable, placeholder: "email@email.com", class: "validate" %>
     </div>
   </div>
   <div class="row">

--- a/features/step_definitions/approval_steps.rb
+++ b/features/step_definitions/approval_steps.rb
@@ -1,6 +1,6 @@
 Given(/^A developer sends me an approval request$/) do
   dev = FactoryGirl::create :developer
-  dev.request_approval_from User.find_by_email(@me.email)
+  Approval.link(@me.id,dev.id,'Developer')
 end
 
 Then(/^I should have an approval$/) do

--- a/features/step_definitions/approval_steps.rb
+++ b/features/step_definitions/approval_steps.rb
@@ -1,6 +1,6 @@
 Given(/^A developer sends me an approval request$/) do
   dev = FactoryGirl::create :developer
-  Approval.link(@me.id,dev.id,'Developer')
+  Approval.link(@me,dev,'Developer')
 end
 
 Then(/^I should have an approval$/) do

--- a/features/step_definitions/permissions_steps.rb
+++ b/features/step_definitions/permissions_steps.rb
@@ -6,11 +6,11 @@ end
 
 Given(/^the developer "(.*?)" sends me an approval request$/) do |dev_name|
   @developer = Developer.find_by(company_name: dev_name)
-  Approval.link(@me.id,@developer.id,'Developer')
+  Approval.link(@me,@developer,'Developer')
 end
 
 Given(/^I accept the approval request$/) do
-  Approval.accept(@me.id,@developer.id,'Developer')
+  Approval.accept(@me,@developer,'Developer')
 end
 
 Then(/^I should see the first "(.*?)" have a class named "(.*?)"$/) do |css, class_name|

--- a/features/step_definitions/permissions_steps.rb
+++ b/features/step_definitions/permissions_steps.rb
@@ -6,11 +6,11 @@ end
 
 Given(/^the developer "(.*?)" sends me an approval request$/) do |dev_name|
   @developer = Developer.find_by(company_name: dev_name)
-  @developer.request_approval_from @me
+  Approval.link(@me.id,@developer.id,'Developer')
 end
 
 Given(/^I accept the approval request$/) do
-  @me.approve_developer(@developer)
+  Approval.accept(@me.id,@developer.id,'Developer')
 end
 
 Then(/^I should see the first "(.*?)" have a class named "(.*?)"$/) do |css, class_name|

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
       # No approval
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to be nil
-      Approval.link(user.id,developer.id,'Developer')
+      Approval.link(user,developer,'Developer')
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to eq "developer-requested"
 
 
-      Approval.accept(user.id,developer.id,'Developer')
+      Approval.accept(user,developer,'Developer')
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to eq "accepted"
     end

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -24,13 +24,12 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
       # No approval
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to be nil
-
-      developer.request_approval_from user
+      Approval.link(user.id,developer.id,'Developer')
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to eq "developer-requested"
 
 
-      user.approve_developer developer
+      Approval.accept(user.id,developer.id,'Developer')
       get :status, user_id: user.username, format: :json
       expect(res_hash[:approval_status]).to eq "accepted"
     end

--- a/spec/controllers/api/v1/users/devices/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices/checkins_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Api::V1::Users::Devices::CheckinsController, type: :controller do
     request.headers["X-Api-Key"] = developer.api_key
     unless example.metadata[:skip_before]
       device
-      developer.request_approval_from(user)
-      user.approve_developer(developer)
+      Approval.link(user.id,developer.id,'Developer')
+      Approval.accept(user.id,developer.id,'Developer')
     end
   end
 

--- a/spec/controllers/api/v1/users/devices/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices/checkins_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Api::V1::Users::Devices::CheckinsController, type: :controller do
     request.headers["X-Api-Key"] = developer.api_key
     unless example.metadata[:skip_before]
       device
-      Approval.link(user.id,developer.id,'Developer')
-      Approval.accept(user.id,developer.id,'Developer')
+      Approval.link(user,developer,'Developer')
+      Approval.accept(user,developer,'Developer')
     end
   end
 

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   let(:device){FactoryGirl::create :device}
   let(:developer) do
     dev = FactoryGirl::create :developer
-    dev.request_approval_from(user)
-    user.approve_developer(dev)
+    Approval.link(user.id,dev.id,'Developer')
+    Approval.accept(user.id,dev.id,'Developer')
     dev
   end
   let(:user) do
@@ -17,8 +17,8 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   end
   let(:second_user) do
     us = FactoryGirl::create :user
-    developer.request_approval_from(us)
-    us.approve_developer(developer)
+    Approval.link(us.id,developer.id,'Developer')
+    Approval.accept(us.id,developer.id,'Developer')
     us
   end
   let(:approval) { create_approval(user, second_user) }

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   let(:device){FactoryGirl::create :device}
   let(:developer) do
     dev = FactoryGirl::create :developer
-    Approval.link(user.id,dev.id,'Developer')
-    Approval.accept(user.id,dev.id,'Developer')
+    Approval.link(user,dev,'Developer')
+    Approval.accept(user,dev,'Developer')
     dev
   end
   let(:user) do
@@ -17,8 +17,8 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   end
   let(:second_user) do
     us = FactoryGirl::create :user
-    Approval.link(us.id,developer.id,'Developer')
-    Approval.accept(us.id,developer.id,'Developer')
+    Approval.link(us,developer,'Developer')
+    Approval.accept(us,developer,'Developer')
     us
   end
   let(:approval) { create_approval(user, second_user) }

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   let(:dev) { FactoryGirl::create :developer }
   let(:user) do
     us = FactoryGirl::create :user
-    dev.request_approval_from(us)
-    us.approve_developer(dev)
+    Approval.link(us.id,dev.id,'Developer')
+    Approval.accept(us.id,dev.id,'Developer')
     us.devices << device
     us
   end
@@ -50,8 +50,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     it 'should assign User.id(:id) to @user if the developer is approved' do
-      dev.request_approval_from user
-      user.approve_developer dev
+      Approval.link(user.id,dev.id,'Developer')
+      Approval.accept(user.id,dev.id,'Developer')
       get :show, {
         id: user.id,
         format: :json

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   let(:dev) { FactoryGirl::create :developer }
   let(:user) do
     us = FactoryGirl::create :user
-    Approval.link(us.id,dev.id,'Developer')
-    Approval.accept(us.id,dev.id,'Developer')
+    Approval.link(us,dev,'Developer')
+    Approval.accept(us,dev,'Developer')
     us.devices << device
     us
   end
@@ -50,8 +50,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     it 'should assign User.id(:id) to @user if the developer is approved' do
-      Approval.link(user.id,dev.id,'Developer')
-      Approval.accept(user.id,dev.id,'Developer')
+      Approval.link(user,dev,'Developer')
+      Approval.accept(user,dev,'Developer')
       get :show, {
         id: user.id,
         format: :json

--- a/spec/controllers/users/approvals_controller_spec.rb
+++ b/spec/controllers/users/approvals_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         post :create, {
           user_id: user.id,
           approval: { 
-            user: developer.email,
+            approvable: developer.email,
             approvable_type: 'Developer'
           }
         }
@@ -44,7 +44,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         post :create, {
           user_id: user.id,
           approval: { 
-            user: developer.email,
+            approvable: developer.email,
             approvable_type: 'Developer'
           }
         }
@@ -59,7 +59,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         post :create, {
           user_id: user.id,
           approval: { 
-            user: friend.email,
+            approvable: friend.email,
             approvable_type: 'User'
           }
         }
@@ -76,7 +76,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         post :create, {
           user_id: user.id,
           approval: { 
-            user: friend.email,
+            approvable: friend.email,
             approvable_type: 'User'
           }
         }
@@ -93,7 +93,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         post :create, {
           user_id: user.id,
           approval: { 
-            user: 'does@not.exist',
+            approvable: 'does@not.exist',
             approvable_type: 'Developer'
           }
         }

--- a/spec/models/developer_spec.rb
+++ b/spec/models/developer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Developer, type: :model do
       expect(developer.pending_approvals.count).to be 0
       expect(developer.users.count).to be 0
 
-      Approval.link(user.id,developer.id,'Developer')
+      Approval.link(user,developer,'Developer')
 
       expect(developer.pending_approvals.count).to be 1
       expect(developer.users.count).to be 0
 
-      Approval.accept(user.id,developer.id,'Developer')
+      Approval.accept(user,developer,'Developer')
 
       expect(developer.pending_approvals.count).to be 0
       expect(developer.users.count).to be 1

--- a/spec/models/developer_spec.rb
+++ b/spec/models/developer_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Developer, type: :model do
       expect(developer.pending_approvals.count).to be 0
       expect(developer.users.count).to be 0
 
-      developer.request_approval_from user
+      Approval.link(user.id,developer.id,'Developer')
 
       expect(developer.pending_approvals.count).to be 1
       expect(developer.users.count).to be 0
 
-      user.approve_developer developer
+      Approval.accept(user.id,developer.id,'Developer')
 
       expect(developer.pending_approvals.count).to be 0
       expect(developer.users.count).to be 1

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,20 +39,20 @@ RSpec.describe User, type: :model do
       expect(user.pending_approvals.count).to be 0
       expect(user.approved_developer? developer).to be false
       
-      user.approvals << Approval.create(approvable_id: developer.id, approvable_type: 'Developer', status: 'developer-requested')
+      user.approvals << Approval.create(approvable: developer, approvable_type: 'Developer', status: 'developer-requested')
       user.save
 
       expect(user.pending_approvals.count).to be 1
       expect(user.developers.count).to be 0
 
-      Approval.accept(user.id,developer.id,'Developer')
+      Approval.accept(user,developer,'Developer')
       expect(user.pending_approvals.count).to be 0
       expect(user.developers.count).to be 1
     end
 
     it "should approve devices for a developer by default when a developer is approved" do
-      user.approvals <<  Approval.create(approvable_id: developer.id, approvable_type: 'Developer', status: 'developer-requested')
-      Approval.accept(user.id,developer.id,'Developer')
+      user.approvals <<  Approval.create(approvable: developer, approvable_type: 'Developer', status: 'developer-requested')
+      Approval.accept(user,developer,'Developer')
       expect(user.devices.first.developers.count).to be 1
       expect(user.devices.first.developers.first).to eq developer
       expect(user.devices.first.privilege_for(developer)).to eq "complete"
@@ -63,8 +63,8 @@ RSpec.describe User, type: :model do
   describe "privileges" do
     context 'between a developer and a user' do
       before do
-        Approval.link(user.id,developer.id,'Developer')
-        Approval.accept(user.id,developer.id,'Developer')
+        Approval.link(user,developer,'Developer')
+        Approval.accept(user,developer,'Developer')
       end
 
       it "should have device privileges by default" do
@@ -80,7 +80,7 @@ RSpec.describe User, type: :model do
 
   describe "notifications" do
     it "should have a notification if there's a pending approval" do
-      Approval.link(user.id,developer.id,'Developer')
+      Approval.link(user,developer,'Developer')
 
       expect(user.notifications).to be_an_instance_of Array
       expect(user.notifications.length).to eq 1

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe User, type: :model do
 
     it "should approve a developer" do
       expect(user.pending_approvals.count).to be 0
-      expect(user.approve_developer(developer)).to be false
+      expect(user.approved_developer? developer).to be false
       
       user.approvals << Approval.create(approvable_id: developer.id, approvable_type: 'Developer', status: 'developer-requested')
       user.save
@@ -45,14 +45,14 @@ RSpec.describe User, type: :model do
       expect(user.pending_approvals.count).to be 1
       expect(user.developers.count).to be 0
 
-      user.approve_developer(developer)
+      Approval.accept(user.id,developer.id,'Developer')
       expect(user.pending_approvals.count).to be 0
       expect(user.developers.count).to be 1
     end
 
     it "should approve devices for a developer by default when a developer is approved" do
       user.approvals <<  Approval.create(approvable_id: developer.id, approvable_type: 'Developer', status: 'developer-requested')
-      user.approve_developer(developer)
+      Approval.accept(user.id,developer.id,'Developer')
       expect(user.devices.first.developers.count).to be 1
       expect(user.devices.first.developers.first).to eq developer
       expect(user.devices.first.privilege_for(developer)).to eq "complete"
@@ -63,8 +63,8 @@ RSpec.describe User, type: :model do
   describe "privileges" do
     context 'between a developer and a user' do
       before do
-        developer.request_approval_from user
-        user.approve_developer developer
+        Approval.link(user.id,developer.id,'Developer')
+        Approval.accept(user.id,developer.id,'Developer')
       end
 
       it "should have device privileges by default" do
@@ -80,7 +80,7 @@ RSpec.describe User, type: :model do
 
   describe "notifications" do
     it "should have a notification if there's a pending approval" do
-      developer.request_approval_from(user)
+      Approval.link(user.id,developer.id,'Developer')
 
       expect(user.notifications).to be_an_instance_of Array
       expect(user.notifications.length).to eq 1


### PR DESCRIPTION
Made sure everywhere an Approval is created/accepted uses the Approval model methods rather than spread across User/Developer models. 
Changed approval method to use User/Developer objects rather than their id's.
Allowed the Approve/Reject Approval controller actions to be used for User approvals.
