### PR TITLE
Api devices controller refactor

### DIFF
--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -7,25 +7,13 @@ class Api::V1::Users::DevicesController < Api::ApiController
   before_action :check_user, only: :update
 
   def index
-    list = []
-    @user.devices.except(:fogged).map do |devc|
-      if devc.privilege_for(@dev) == "complete"
-        list << devc.device_checkin_hash
-      end
-    end
-    respond_with list
+    devices = @user.devices
+    render json: devices
   end
 
   def show
-    list = []
-    @user.devices.where(id: params[:id]).except(:fogged).map do |devc|
-      if devc.privilege_for(@dev) == "complete"
-        list << devc.device_checkin_hash
-      else
-        return head status: :unauthorized
-      end
-    end
-    respond_with list
+    device = @user.devices.where(id: params[:id])
+    render json: device
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
 
   def area_name(checkin)
-    City.near(checkin).first[:name] unless Rails.env.test?
+    checkin.nearest_city.name unless Rails.env.test?
   end
 
 end

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -30,7 +30,7 @@ class Checkin < ActiveRecord::Base
     if fogged?
       fogged_checkin.lat = nearest_city.latitude
       fogged_checkin.lng = nearest_city.longitude
-      fogged_checkin.address = "#{city}, #{country_code}"
+      fogged_checkin.address = "#{nearest_city.name}, #{nearest_city.country_code}"
       fogged_checkin
     else
       self
@@ -50,6 +50,6 @@ class Checkin < ActiveRecord::Base
   end
 
   def nearest_city
-    @nearest_city ||= City.where(name: city, country_code: country_code).near(self).first
+    @nearest_city ||= City.near(self).first || NoCity.new
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -24,12 +24,6 @@ class Device < ActiveRecord::Base
     checkins << Checkin.create(uuid: uuid, lat: lat, lng: lng)
   end
 
-  def device_checkin_hash
-    hash = as_json
-    hash[:last_checkin] = checkins.last.get_data if checkins.exists?
-    hash
-  end
-
   def slack_message
     "A new device has been created"
   end

--- a/lib/no_city.rb
+++ b/lib/no_city.rb
@@ -1,0 +1,5 @@
+class NoCity
+  def name
+    'No near cities'
+  end
+end

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
   end
   let(:approval) { create_approval(user, second_user) }
 
-  before do      
+  before do
     @checkin = FactoryGirl::build :checkin
     @checkin.uuid = device.uuid
     @checkin.save
@@ -51,29 +51,6 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
       expect(res_hash.first["id"]).to be device.id
     end
 
-    it "should let you know the last checkin for devices if there is one" do
-      req = Proc.new { |loc| get loc, user_id: user.username, id: device.id, format: :json }
-      expect = Proc.new { expect(res_hash.first["last_checkin"]["id"]).to eq @checkin.id }
-      
-      req.call(:index)
-      expect.call
-      req.call(:show)
-      expect.call
-    end
-
-    it "should not only return devices for which the developer has permission" do
-      device.permissions.last.update(privilege: "disallowed")
-      get :index, user_id: user.username, format: :json
-      expect(response.body).to eq "[]"
-      expect(response.status).to be 200
-    end
-
-    it "should not allow a developer to see a device for which it disallowed" do
-      device.permissions.last.update(privilege: "disallowed")
-      get :show, user_id: user.username, id: device.id, format: :json
-      expect(response.body).to eq ""
-      expect(response.status).to be 401
-    end
   end
 
   describe "PUT" do


### PR DESCRIPTION
Removed last checkin from index/show response in API devices controller as quite a lot of logic has to take place to decide whether the dev/user can see a checkin and think this should stay in the Checkins Controller.
Also built a null object to cover scenarios when City.near does not return a city, i.e. there are no large cities near the coordinates given.
Nearest_city only worked when passed geocoded checkins so changed it so it would work with non-geocoded checkins.
Get_data now uses the nearest_city city and country for fogged checkins address instead of the geocoded city/country (which may not always be present).