### PR TITLE
Revoke approval destroys permissions

### DIFF
--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -56,11 +56,11 @@ class Users::ApprovalsController < ApplicationController
   def reject
     @approval = Approval.where(id: params[:id],
       user: current_user).first
+    current_user.destroy_permissions_for(@approval.approvable)
     if @approval.approvable_type == 'User'
       Approval.where(user: @approval.approvable, approvable: @approval.user, approvable_type: 'User').first.destroy
     end
     @approval.destroy
-    current_user.destroy_permissions_for(@approval.approvable)
     @approved_devs = current_user.developers
     @friends = current_user.friends
     @friend_requests = current_user.friend_requests

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -60,6 +60,7 @@ class Users::ApprovalsController < ApplicationController
       Approval.where(user: @approval.approvable, approvable: @approval.user, approvable_type: 'User').first.destroy
     end
     @approval.destroy
+    destroy_permissions
     @approved_devs = current_user.developers
     @friends = current_user.friends
     @friend_requests = current_user.friend_requests
@@ -86,6 +87,13 @@ class Users::ApprovalsController < ApplicationController
 
     def allowed_params
       params.require(:approval).permit(:approvable, :approvable_type)
+    end
+
+    def destroy_permissions
+      current_user.devices.each do |device|
+        permission = device.permissions.where(permissible: @approval.approvable).first
+        permission.destroy if permission
+      end
     end
 
 end

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -60,7 +60,7 @@ class Users::ApprovalsController < ApplicationController
       Approval.where(user: @approval.approvable, approvable: @approval.user, approvable_type: 'User').first.destroy
     end
     @approval.destroy
-    destroy_permissions
+    current_user.destroy_permissions_for(@approval.approvable)
     @approved_devs = current_user.developers
     @friends = current_user.friends
     @friend_requests = current_user.friend_requests
@@ -87,13 +87,6 @@ class Users::ApprovalsController < ApplicationController
 
     def allowed_params
       params.require(:approval).permit(:approvable, :approvable_type)
-    end
-
-    def destroy_permissions
-      current_user.devices.each do |device|
-        permission = device.permissions.where(permissible: @approval.approvable).first
-        permission.destroy if permission
-      end
     end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,12 +8,12 @@ class User < ActiveRecord::Base
   friendly_id :username, use: [:slugged, :finders]
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, 
+         :recoverable, :rememberable, :trackable, :validatable,
          :authentication_keys => { username: false, email: true }
 
-  validates :username, uniqueness: true, 
-                       allow_blank: true, 
-                       format: { with: /\A[-a-zA-Z_]+\z/, 
+  validates :username, uniqueness: true,
+                       allow_blank: true,
+                       format: { with: /\A[-a-zA-Z_]+\z/,
                          message: "only allows letters, underscores and dashes" }
 
   has_many :devices, dependent: :destroy
@@ -42,6 +42,13 @@ class User < ActiveRecord::Base
 
   def has_request_from(approvable)
     friend_requests.include?(approvable) || developer_requests.include?(approvable)
+  end
+
+  def destroy_permissions_for(approvable)
+    devices.each do |device|
+      permission = device.permissions.where(permissible: approvable).first
+      permission.destroy if permission
+    end
   end
 
   ## Devices

--- a/spec/controllers/users/approvals_controller_spec.rb
+++ b/spec/controllers/users/approvals_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
 
   let(:user) do
     user = create_user
+    user.devices << FactoryGirl::create(:device)
     user
   end
   let(:friend){FactoryGirl::create :user}
@@ -28,14 +29,14 @@ RSpec.describe Users::ApprovalsController, type: :controller do
       it 'should create an accepted approval between user and developer' do
         post :create, {
           user_id: user.id,
-          approval: { 
+          approval: {
             approvable: developer.email,
             approvable_type: 'Developer'
           }
         }
         expect(Approval.last.user).to eq user
         expect(Approval.last.approvable_id).to eq developer.id
-        expect(Approval.last.status).to eq 'accepted' 
+        expect(Approval.last.status).to eq 'accepted'
       end
 
       it 'should confirm an existing developer approval request' do
@@ -43,7 +44,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         count = Approval.count
         post :create, {
           user_id: user.id,
-          approval: { 
+          approval: {
             approvable: developer.email,
             approvable_type: 'Developer'
           }
@@ -58,7 +59,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
       it 'should create a pending approval and a friend request with a user' do
         post :create, {
           user_id: user.id,
-          approval: { 
+          approval: {
             approvable: friend.email,
             approvable_type: 'User'
           }
@@ -75,7 +76,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         approval_two.update(status: 'pending', approvable_id: user.id, approvable_type: 'User')
         post :create, {
           user_id: user.id,
-          approval: { 
+          approval: {
             approvable: friend.email,
             approvable_type: 'User'
           }
@@ -92,7 +93,7 @@ RSpec.describe Users::ApprovalsController, type: :controller do
       it 'should not create or approve an approval if user/dev doesnt exist' do
         post :create, {
           user_id: user.id,
-          approval: { 
+          approval: {
             approvable: 'does@not.exist',
             approvable_type: 'Developer'
           }
@@ -143,6 +144,19 @@ RSpec.describe Users::ApprovalsController, type: :controller do
         user_id: user,
         id: approval.id
       }
+      expect(Approval.count).to eq 0
+    end
+
+    it 'should destroy an existing approval and permissions' do
+      approval.update(status: 'developer-requested', approvable_id: developer.id, approvable_type: 'Developer')
+      approval.approve!
+      expect(Permission.count).to eq 1
+      request.accept = 'text/javascript'
+      post :reject, {
+        user_id: user,
+        id: approval.id
+      }
+      expect(Permission.count).to eq 0
       expect(Approval.count).to eq 0
     end
   end


### PR DESCRIPTION
Previously revoking an approval did not destroy the permissions for the approved user/developer. Now it does.