### PR TITLE
Device global update privilege

### DIFF
--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -1,8 +1,8 @@
 class  Api::V1::Users::PermissionsController < Api::ApiController
   respond_to :json
-  
+
   acts_as_token_authentication_handler_for User
-  
+
   before_action :require_ownership
 
   def update
@@ -11,14 +11,24 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
     render json: permission
   end
 
+  def update_all
+    device = Device.find(params[:device_id])
+    permissions = device.permissions
+    permissions.update_all(allowed_params)
+    render json: permissions
+  end
+
   private
     def allowed_params
       params.require(:permission).permit(:privilege, :bypass_fogging, :show_history)
     end
 
     def require_ownership
-      unless user_owns_permission?
-        render status: 403, json: { message: "You do not control that permission" }
+      if params[:id]
+        render status: 403, json: { message: "You do not control that permission" } unless user_owns_permission?
+      else
+        params[:id] = params[:device_id]
+        render status: 403, json: { message: "You do not control that device" } unless user_owns_device?
       end
     end
 end

--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -6,9 +6,11 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
   before_action :require_ownership
 
   def update
-    permission = Permission.find(params[:id])
-    permission.update(allowed_params)
-    render json: permission
+    permission = Permission.where(id: params[:id], device_id: params[:device_id]).first
+    if permission_exists? permission
+      permission.update(allowed_params)
+      render json: permission
+    end
   end
 
   def update_all
@@ -23,11 +25,7 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
     end
 
     def require_ownership
-      if params[:id]
-        render status: 403, json: { message: "You do not control that permission" } unless user_owns_permission?
-      else
-        params[:id] = params[:device_id]
-        render status: 403, json: { message: "You do not control that device" } unless user_owns_device?
-      end
+      params[:id] = params[:device_id]
+      render status: 403, json: { message: "You do not control that device" } unless user_owns_device?
     end
 end

--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -6,11 +6,9 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
   before_action :require_ownership
 
   def update
-    permission = Permission.where(id: params[:id], device_id: params[:device_id]).first
-    if permission_exists? permission
-      permission.update(allowed_params)
-      render json: permission
-    end
+    permission = Permission.find(params[:id])
+    permission.update(allowed_params)
+    render json: permission
   end
 
   def update_all
@@ -25,7 +23,11 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
     end
 
     def require_ownership
-      params[:id] = params[:device_id]
-      render status: 403, json: { message: "You do not control that device" } unless user_owns_device?
+      if params[:id]
+        render status: 403, json: { message: "You do not control that permission" } unless user_owns_permission?
+      else
+        params[:id] = params[:device_id]
+        render status: 403, json: { message: "You do not control that device" } unless user_owns_device?
+      end
     end
 end

--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -12,8 +12,7 @@ class  Api::V1::Users::PermissionsController < Api::ApiController
   end
 
   def update_all
-    device = Device.find(params[:device_id])
-    permissions = device.permissions
+    permissions = Permission.where(device_id: params[:device_id])
     permissions.update_all(allowed_params)
     render json: permissions
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,11 +48,8 @@ Rails.application.routes.draw do
               get :last
             end
           end
-          resources :permissions, only: [:update] do
-            collection do
-              put :update_all
-            end
-          end
+          resources :permissions, only: [:update]
+          put '/permissions', to: 'permissions#update_all'
         end
       end
       namespace :mobile_app do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,11 @@ Rails.application.routes.draw do
               get :last
             end
           end
-          resources :permissions, only: [:update]
+          resources :permissions, only: [:update] do
+            collection do
+              put :update_all
+            end
+          end
         end
       end
       namespace :mobile_app do

--- a/spec/controllers/api/v1/users/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/users/permissions_controller_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
     u.devices << device
     u
   end
-  let(:second_user) { FactoryGirl::create :user }
+  let(:second_user) do
+    u = FactoryGirl::create :user
+    u.devices << second_device
+    u
+  end
   let(:developer) { FactoryGirl::create :developer }
   let(:permission) do
     device.permitted_users << second_user
@@ -40,11 +44,11 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
       request.headers["X-User-Email"] = second_user.email
       put :update, {
         user_id: second_user.id,
-        device_id: device.id,
+        device_id: second_device.id,
         id: permission.id,
       }
-      expect(response.status).to be 403
-      expect(res_hash[:message]).to eq 'You do not control that permission'
+      expect(response.status).to be 404
+      expect(res_hash[:message]).to eq 'Permission does not exist'
     end
   end
 

--- a/spec/controllers/api/v1/users/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/users/permissions_controller_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
         device_id: second_device.id,
         id: permission.id,
       }
-      expect(response.status).to be 404
-      expect(res_hash[:message]).to eq 'Permission does not exist'
+      expect(response.status).to be 403
+      expect(res_hash[:message]).to eq 'You do not control that permission'
     end
   end
 

--- a/spec/controllers/api/v1/users/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/users/permissions_controller_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
         device_id: device.id,
         user_id: user.id,
         permission: {
-          show_history: true,
+          privilege: 1,
         },
       }
       expect(res_hash.count).to eq 2
-      expect(res_hash.all? { |permission| permission["show_history"] == true }).to eq true
+      expect(res_hash.all? { |permission| permission["privilege"] == "last_only" }).to eq true
     end
 
     it "should fail to update if user does not own device" do


### PR DESCRIPTION
Added an update_all action which updates all the permissions on a device (mainly will be used for the 'disable' toggle as shown in invision on the app).
Made route devices/:device_id/permissions/ because it makes sense.
Tests.