### PR TITLE
Removing wfat logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,4 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def current_user?(user_id)
-    current_user == User.find(user_id)
-  end
-
 end

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -27,13 +27,6 @@ class Users::ApprovalsController < ApplicationController
 
   def apps
     @apps = current_user.developers
-    # Redirect if foreign app failed to create a pending approval.
-    if @apps.length == 0 && current_user.pending_approvals.length == 0 && params[:redirect]
-      developer = Developer.find_by(api_key: params[:api_key])
-      Approval.link(current_user, developer, 'Developer')
-    elsif current_user.pending_approvals.length == 0 && params[:redirect]
-      redirect_to params[:redirect]
-    end
   end
 
   def friends

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -1,7 +1,6 @@
 class Users::ApprovalsController < ApplicationController
 
   before_action :authenticate_user!
-  before_action :check_user, only: :index
 
   def new
     @approval = Approval.new
@@ -62,13 +61,6 @@ class Users::ApprovalsController < ApplicationController
   end
 
   private
-
-    def check_user
-      unless current_user?(params[:user_id])
-        developer = Developer.find_by(api_key: params[:api_key])
-        redirect_to developer.redirect_url+"?copo_user=#{current_user.username}"
-      end
-    end
 
     def allowed_params
       params.require(:approval).permit(:approvable, :approvable_type)

--- a/app/controllers/users/devise/sessions_controller.rb
+++ b/app/controllers/users/devise/sessions_controller.rb
@@ -55,8 +55,8 @@ class Users::Devise::SessionsController < Devise::SessionsController
       true
     end
 
-    #def after_sign_in_path_for(_resource)
-    #  user_dashboard_path(current_user)
-    #end
+    def after_sign_in_path_for(resource)
+      stored_location_for(resource) || user_dashboard_path(current_user)
+    end
 
 end

--- a/app/controllers/users/devise/sessions_controller.rb
+++ b/app/controllers/users/devise/sessions_controller.rb
@@ -55,8 +55,8 @@ class Users::Devise::SessionsController < Devise::SessionsController
       true
     end
 
-    def after_sign_in_path_for(_resource)
-      user_dashboard_path(current_user)
-    end
+    #def after_sign_in_path_for(_resource)
+    #  user_dashboard_path(current_user)
+    #end
 
 end

--- a/app/controllers/users/devise/sessions_controller.rb
+++ b/app/controllers/users/devise/sessions_controller.rb
@@ -56,7 +56,7 @@ class Users::Devise::SessionsController < Devise::SessionsController
     end
 
     def after_sign_in_path_for(resource)
-      stored_location_for(resource) || user_dashboard_path(current_user)
+      stored_location_for(resource) || user_dashboard_path(resource)
     end
 
 end


### PR DESCRIPTION
Removed code which stopped foreign apps trying to create an approval from breaking, realised could be done by the foreign app. (e.g. checking if the user had already approved the app).

Updated the sign in path to default to dashboard but use the page the user was trying to access otherwise.