### PR TITLE
Remove paperclip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rack-cors', :require => 'rack/cors'
 gem 'factory_girl_rails'
 gem 'faker'
 gem 'geocoder'
-gem "paperclip", "~> 4.3"
 gem 'colorize'
 gem 'simple_token_authentication'
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,13 +61,9 @@ GEM
       xpath (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    climate_control (0.0.3)
-      activesupport (>= 3.0)
     cloudinary (1.1.3)
       aws_cf_signer
       rest-client
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
@@ -205,7 +201,6 @@ GEM
       railties (>= 3.0.0, < 5.1.0)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mimemagic (0.3.0)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
@@ -219,12 +214,6 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    paperclip (4.3.5)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      cocaine (~> 0.5.5)
-      mime-types
-      mimemagic (= 0.3.0)
     pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -406,7 +395,6 @@ DEPENDENCIES
   materialize-sass
   meta_request
   newrelic_rpm
-  paperclip (~> 4.3)
   pg
   pry
   pry-byebug

--- a/db/migrate/20151027114001_add_logo_to_developer.rb
+++ b/db/migrate/20151027114001_add_logo_to_developer.rb
@@ -1,9 +1,0 @@
-class AddLogoToDeveloper < ActiveRecord::Migration
-  def up
-    add_attachment :developers, :logo
-  end
-
-  def down
-    remove_attachment :developers, :logo
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 20160316121833) do
     t.string   "company_name",                        null: false
     t.string   "tagline"
     t.string   "redirect_url"
-    t.string   "avatar"
   end
 
   add_index "developers", ["email"], name: "index_developers_on_email", unique: true, using: :btree
@@ -156,7 +155,6 @@ ActiveRecord::Schema.define(version: 20160316121833) do
     t.string   "username",                            null: false
     t.string   "slug"
     t.string   "authentication_token"
-    t.string   "avatar"
   end
 
   add_index "users", ["authentication_token"], name: "index_users_on_authentication_token", using: :btree


### PR DESCRIPTION
Rolled back migration adding logo:
rake db:migrate:down VERSION=20151027114001
Destroyed migration:
rails d migration AddLogoToDeveloper
Deleted gem, bundled.

Anyone with a local copy of Coposition that has been migrated in the last 3 months or so will need to run rake db:migrate:down VERSION=20151027114001 after pulling down from dev after this merge.