### PR TITLE
Improve device show

### DIFF
--- a/app/controllers/api/v1/users/checkins_controller.rb
+++ b/app/controllers/api/v1/users/checkins_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Users::CheckinsController < Api::ApiController
 
   def index
     params[:per_page].to_i <= 1000 ? per_page = params[:per_page] : per_page = 1000
-    checkins = @user.get_checkins(@permissible, @device).order('created_at DESC') \
+    checkins = @user.get_checkins(@permissible, @device).order(created_at: :desc) \
       .paginate(page: params[:page], per_page: per_page)
     paginated_response_headers(checkins)
     checkins = checkins.map do |checkin|
@@ -18,7 +18,7 @@ class Api::V1::Users::CheckinsController < Api::ApiController
   end
 
   def last
-    checkin = @user.get_checkins(@permissible, @device).last
+    checkin = @user.get_checkins(@permissible, @device).order(created_at: :desc).first
     checkin = checkin.resolve_address(@permissible, params[:type]) if checkin
     if checkin
       render json: [checkin]

--- a/app/controllers/api/v1/users/requests_controller.rb
+++ b/app/controllers/api/v1/users/requests_controller.rb
@@ -5,9 +5,9 @@ class Api::V1::Users::RequestsController < Api::ApiController
 
   def index
     if params[:developer_id]
-      requests = @user.requests.where(developer_id: params[:developer_id]).order('created_at DESC').paginate(page: params[:page])
+      requests = @user.requests.where(developer_id: params[:developer_id]).paginate(page: params[:page])
     else
-      requests = @user.requests.order('created_at DESC').paginate(page: params[:page])
+      requests = @user.requests.paginate(page: params[:page])
     end
     paginated_response_headers(requests)
     render json: requests

--- a/app/controllers/api/v1/users/requests_controller.rb
+++ b/app/controllers/api/v1/users/requests_controller.rb
@@ -16,12 +16,12 @@ class Api::V1::Users::RequestsController < Api::ApiController
   def last
     if params[:developer_id] == @dev.id.to_s
       # We use [-2] instead of .last because the last request will ironically be the one you're making
-      requests = @user.requests.where(developer_id: params[:developer_id])[-2]
+      requests = @user.requests.where(developer_id: params[:developer_id]).second
     elsif params[:developer_id]
       # If we're checking someone else's last request, go ahead and show their last one
-      requests = @user.requests.where(developer_id: params[:developer_id]).last
+      requests = @user.requests.where(developer_id: params[:developer_id]).first
     else
-      requests = @user.requests[-2]
+      requests = @user.requests.second
     end
     render json: [requests]
   end

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -7,7 +7,7 @@ class Users::DevicesController < ApplicationController
   def index
     gon.current_user_id = current_user.id
     @devices = current_user.devices.includes(:developers, :permitted_users, :permissions).map do |dev|
-      dev.checkins.order('created_at DESC').first.reverse_geocode! if dev.checkins.exists?
+      dev.checkins.first.reverse_geocode! if dev.checkins.exists?
       dev
     end
     gon.permissions = @devices.map(&:permissions).inject(:+)
@@ -16,12 +16,12 @@ class Users::DevicesController < ApplicationController
   def show
     @device = Device.find(params[:id])
     @from, @to = date_range
-    @checkins = Checkin.where(device_id: @device.id, created_at: @from..@to)
+    @checkins = @device.checkins.where(created_at: @from..@to)
     if @checkins.empty?
-      flash[:notice] = "Showing last month's checkins if available"
-      @checkins = Checkin.where(device_id: @device.id, created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day)
+      flash[:notice] = "Showing most recent checkins available"
+      @checkins = @device.checkins.where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day)
     end
-    @checkins = @checkins.order('created_at DESC').paginate(page: params[:page], per_page: 1000)
+    @checkins = @checkins.paginate(page: params[:page], per_page: 1000)
     gon.checkins = @checkins
     gon.current_user_id = current_user.id
   end
@@ -33,7 +33,7 @@ class Users::DevicesController < ApplicationController
 
   def shared
     device = Device.find(params[:id])
-    checkin = device.checkins.order('created_at DESC').first
+    checkin = device.checkins.first
     gon.device = device
     user = device.user.as_json
     user['avatar'] = device.user.avatar.as_json({})

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -16,9 +16,8 @@ class Users::DevicesController < ApplicationController
   def show
     @device = Device.find(params[:id])
     @from, @to = date_range
-    @checkins = @device.checkins.where(created_at: @from..@to).paginate(page: params[:page], per_page: 1000)
-    flash[:notice] = "No checkins available" if @checkins.empty?
-    gon.checkins = @checkins
+    gon.checkins = @device.checkins.where(created_at: @from..@to).paginate(page: params[:page], per_page: 1000)
+    flash[:notice] = "No checkins available" if gon.checkins.empty?
     gon.current_user_id = current_user.id
   end
 

--- a/app/controllers/users/friends_controller.rb
+++ b/app/controllers/users/friends_controller.rb
@@ -9,13 +9,11 @@ class Users::FriendsController < ApplicationController
   def show_device
     @friend = User.find(params[:id])
     @device = @friend.devices.find(params[:device_id])
-    @paginated_checkins = @friend.get_checkins(current_user, @device).order(created_at: :desc) \
+    gon.checkins = @friend.get_checkins(current_user, @device).order(created_at: :desc) \
       .paginate(page: params[:page], per_page: 1000)
-    @checkins = @paginated_checkins
-    @checkins = @checkins.map do |checkin|
+    gon.checkins = gon.checkins.map do |checkin|
       checkin.get_data
     end unless @device.can_bypass_fogging?(current_user)
-    gon.checkins = @paginated_checkins
   end
 
   private

--- a/app/controllers/users/friends_controller.rb
+++ b/app/controllers/users/friends_controller.rb
@@ -9,7 +9,7 @@ class Users::FriendsController < ApplicationController
   def show_device
     @friend = User.find(params[:id])
     @device = @friend.devices.find(params[:device_id])
-    @paginated_checkins = @friend.get_checkins(current_user, @device).order('created_at DESC') \
+    @paginated_checkins = @friend.get_checkins(current_user, @device).order(created_at: :desc) \
       .paginate(page: params[:page], per_page: 1000)
     @checkins = @paginated_checkins
     @checkins = @checkins.map do |checkin|

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -6,8 +6,7 @@ module DevicesHelper
 
   def devices_last_checkin(device)
     if device.checkins.exists?
-      checkins = device.checkins.order('created_at DESC')
-      "<p>Last reported in #{checkins.first.address}</p>".html_safe
+      "<p>Last reported in #{device.checkins.first.address}</p>".html_safe
     else
       "<p>No Checkins found</p>".html_safe
     end

--- a/app/helpers/friends_helper.rb
+++ b/app/helpers/friends_helper.rb
@@ -6,7 +6,6 @@ module FriendsHelper
 
   def friends_last_checkin(checkins)
     if checkins.present?
-      checkins = checkins.order('created_at DESC')
       "<p>Last available reported area: #{checkins.first.fogged_area}</p>".html_safe
     else
       "<p>No location found</p>".html_safe

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -7,6 +7,7 @@ class Checkin < ActiveRecord::Base
 
   delegate :user, to: :device
 
+  default_scope { order(created_at: :desc) }
   scope :since, -> (date) { where("created_at > ?", date)}
   scope :before, -> (date) { where("created_at < ?", date)}
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -20,9 +20,8 @@ class Device < ActiveRecord::Base
 
   def permitted_history_for(permissible)
     return Checkin.none if permission_for(permissible).privilege == "disallowed"
-
     if permission_for(permissible).privilege == "last_only"
-      can_bypass_delay?(permissible) ? Checkin.where(id: checkins.last.id) : Checkin.where(id: checkins.before(delayed.to_i.minutes.ago).last.id)
+      can_bypass_delay?(permissible) ? Checkin.where(id: checkins.first.id) : Checkin.where(id: checkins.before(delayed.to_i.minutes.ago).first.id)
     else
       can_bypass_delay?(permissible) ? checkins : checkins.before(delayed.to_i.minutes.ago)
     end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,4 +1,5 @@
 class Request < ActiveRecord::Base
   belongs_to :developer
   scope :recent, ->(time) { where("created_at > ?", time) }
+  default_scope { order(created_at: :desc) }
 end

--- a/app/views/users/devices/show.html.erb
+++ b/app/views/users/devices/show.html.erb
@@ -35,8 +35,6 @@
       <%= link_to("Delete history", user_device_checkins_path(current_user.url_id, @device.id), { method: :delete, class: "btn red white-text", data: { confirm: 'Delete all checkins for this device?' } })%>
       <%= link_to("Delete device", user_device_path(current_user.url_id, @device), { method: :delete, class: "btn red white-text", data: { confirm: 'Are you sure?' } })%>
     </div>
-
-    <%= will_paginate @checkins %>
   </div>
 
 <% end %>

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Api::V1::Users::CheckinsController, type: :controller do
     context 'with no page param given' do
       it "should fetch the most recent checkins (up to 30 checkins)" do
         get :index, params
-        expect(res_hash.first['id']).to be device.checkins.last.id
+        expect(res_hash.first['id']).to be device.checkins.first.id
         expect(response.header['X-Next-Page']).to eq "2"
         expect(response.header['X-Current-Page']).to eq "1"
         expect(response.header['X-Total-Entries']).to eq "#{device.checkins.count}"
@@ -128,7 +128,7 @@ RSpec.describe Api::V1::Users::CheckinsController, type: :controller do
       it "should fetch the checkins on that page if they exist" do
         page = 2
         get :index, params.merge(page: page)
-        expect(res_hash.first['id']).to be device.checkins.first.id
+        expect(res_hash.first['id']).to be device.checkins.last.id
         expect(response.header['X-Current-Page']).to eq "#{page}"
         expect(response.header['X-Next-Page']).to eq "null"
       end
@@ -143,7 +143,7 @@ RSpec.describe Api::V1::Users::CheckinsController, type: :controller do
     context "on a user" do
       it "should fetch the most recent checkins (up to 30 checkins)" do
         get :index, { user_id: user.id }
-        expect(res_hash.first['id']).to be device.checkins.last.id
+        expect(res_hash.first['id']).to be device.checkins.first.id
       end
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       count = dev.requests.count
       get :index, format: :json
       expect(dev.requests.count).to eq count + 1
-      expect(dev.requests.last.paid).to eq false
+      expect(dev.requests.first.paid).to eq false
     end
 
     it 'should assign User.id(:id) to @user if the developer is approved' do

--- a/spec/controllers/users/checkins_controller_spec.rb
+++ b/spec/controllers/users/checkins_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Users::CheckinsController, type: :controller do
       }
       expect(assigns :device).to eq(Device.find(device.id))
       expect(device.checkins.count).to eq count + 1
-      expect(assigns :checkin).to eq(Checkin.last)
+      expect(assigns :checkin).to eq(device.checkins.first)
     end
   end
 

--- a/spec/controllers/users/devices_controller_spec.rb
+++ b/spec/controllers/users/devices_controller_spec.rb
@@ -44,11 +44,6 @@ RSpec.describe Users::DevicesController, type: :controller do
       expect(assigns :device).to eq(Device.find(device.id))
     end
 
-    it 'should assign :id.device to @device if user owns device' do
-      get :show, date_params
-      expect(assigns :checkins).to eq([checkin])
-    end
-
     it 'should not assign to @device if user does not own device' do
       get :show, params.merge(user_id: new_user.username)
       expect(response).to redirect_to(root_path)

--- a/spec/controllers/users/friends_controller_spec.rb
+++ b/spec/controllers/users/friends_controller_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Users::FriendsController, type: :controller do
       get :show_device, params
       expect(assigns :friend).to eq(second_user)
       expect(assigns :device).to eq(device)
-      expect(assigns :checkins).to eq(device.checkins)
     end
   end
 end

--- a/spec/helpers/friends_helper_spec.rb
+++ b/spec/helpers/friends_helper_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe FriendsHelper, :type => :helper do
 
     it "returns the last checkin address if it exists" do
       expect(helper.friends_last_checkin(device.checkins)).to match('Last available')
-      expect(helper.friends_last_checkin(device.checkins)).to match(device.checkins.last.fogged_area.to_s)
+      expect(helper.friends_last_checkin(device.checkins)).to match(device.checkins.first.fogged_area.to_s)
     end
   end
 end


### PR DESCRIPTION
Request/checkins now ordered by created_at by default.

Modified devices#show so that if user has checkins, shows last month from date of most recent checkin.

If user enters date range which contains no checkins, displays no checkins instead of last months checkins.