### PR TITLE
Fogged check for device shared page

### DIFF
--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -30,7 +30,7 @@ class Users::DevicesController < ApplicationController
     checkin = device.checkins.first
     gon.device = device
     gon.user = device.user.public_info
-    gon.checkin = checkin.reverse_geocode! if checkin
+    gon.checkin = checkin.reverse_geocode!.get_data if checkin
   end
 
   def create

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -34,10 +34,10 @@ class Checkin < ActiveRecord::Base
 
   def get_data
     fogged_checkin = self
-    if fogged?
+    if fogged? || device.fogged?
       fogged_checkin.address = "#{nearest_city.name}, #{nearest_city.country_code}"
-      fogged_checkin.lat = self.fogged_lat || nearest_city.latitude || self.lat + rand(-0.5..0.5)
-      fogged_checkin.lng = self.fogged_lng || nearest_city.longitude || self.lng + rand(-0.5..0.5)
+      fogged_checkin.lat = fogged_checkin.fogged_lat
+      fogged_checkin.lng = fogged_checkin.fogged_lng
       fogged_checkin
     else
       self

--- a/spec/helpers/checkins_helper_spec.rb
+++ b/spec/helpers/checkins_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CheckinsHelper, :type => :helper do
   let(:device) { FactoryGirl::create(:device) }
   let(:checkin) do
     checkin = FactoryGirl::create(:checkin)
-    checkin.device = device
+    checkin.update(device_id: device.id)
     checkin
   end
   let(:fogged) { FactoryGirl::create(:checkin, fogged: true) }


### PR DESCRIPTION
Made sure that fogged data is shown if the device or the checkin is fogged.

Made sure fogged data is shown on device shared page.

Realised that calling reverse_geocode! after get_data overwrites the checkin as reverse_geocode calls save on the checkin passed to it. So don't do this.