### PR TITLE
Reduce spec duplication

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -160,6 +160,6 @@ window.COPO.maps = {
 
     }).addTo(map);
 
-  },
+  }
 }
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,7 +25,13 @@ class Device < ActiveRecord::Base
   def permitted_history_for(permissible)
     return Checkin.none if permission_for(permissible).privilege == "disallowed"
     if permission_for(permissible).privilege == "last_only"
-      can_bypass_delay?(permissible) ? Checkin.where(id: checkins.first.id) : Checkin.where(id: checkins.before(delayed.to_i.minutes.ago).first.id)
+      if can_bypass_delay?(permissible)
+        Checkin.where(id: checkins.first.id)
+      elsif checkins.before(delayed.to_i.minutes.ago).present?
+        Checkin.where(id: checkins.before(delayed.to_i.minutes.ago).first.id)
+      else
+        Checkin.none
+      end
     else
       can_bypass_delay?(permissible) ? checkins : checkins.before(delayed.to_i.minutes.ago)
     end

--- a/features/step_definitions/developer_steps.rb
+++ b/features/step_definitions/developer_steps.rb
@@ -1,3 +1,3 @@
-Given (/^I have an unpaid request$/) do
+Given(/^I have an unpaid request$/) do
   @developer.requests.create(action: 'last', controller: 'api/v1/users/checkins')
 end

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -20,13 +20,6 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     Approval.accept(user,developer,'Developer')
   end
 
-  def last(priv, delay, params, result)
-    device.permission_for(developer).update! privilege: priv
-    device.permission_for(developer).update! bypass_delay: delay
-    get :last, params
-    expect(res_hash.size).to be result
-  end
-
   describe "GET #last" do
 
     context 'with 2 checkins: 1 old, 1 new.' do
@@ -37,37 +30,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_last(0, false, params, 0, nil)
+          call_checkin_method('last', 0, false, params, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_last(0, true, params, 0, nil)
+          call_checkin_method('last', 0, true, params, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_last(1, true, params, 1, checkin)
+          call_checkin_method('last', 1, true, params, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_last(1, false, params, 1, historic_checkin)
+          call_checkin_method('last', 1, false, params, 1, historic_checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_last(2, true, params, 1, checkin)
+          call_checkin_method('last', 2, true, params, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_last(2, false, params, 1, historic_checkin)
+          call_checkin_method('last', 2, false, params, 1, historic_checkin)
         end
       end
     end
@@ -80,38 +73,38 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_last(0, false, params, 0, nil)
+          call_checkin_method('last', 0, false, params, 0, nil)
 
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_last(0, true, params, 0, nil)
+          call_checkin_method('last', 0, true, params, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_last(1, true, params, 1, checkin)
+          call_checkin_method('last', 1, true, params, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_last(1, false, params, 0, nil)
+          call_checkin_method('last', 1, false, params, 0, nil)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 checkin" do
-          call_last(2, true, params, 1, checkin)
+          call_checkin_method('last', 2, true, params, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_last(2, false, params, 0, nil)
+          call_checkin_method('last', 2, false, params, 0, nil)
         end
       end
 
@@ -129,57 +122,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          device.permission_for(developer).update! privilege: 0
-          get :index, params
-          expect(res_hash.size).to be(0)
+          call_checkin_method('index', 0, false, params, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          device.permission_for(developer).update! privilege: 0
-          device.permission_for(developer).update! bypass_delay: true
-          get :index, params
-          expect(res_hash.size).to be(0)
+          call_checkin_method('index', 0, true, params, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          device.permission_for(developer).update! privilege: 1
-          device.permission_for(developer).update! bypass_delay: true
-          get :index, params
-          expect(res_hash.size).to be(1)
-          expect(res_hash.first['id']).to be(checkin.id)
+          call_checkin_method('index', 1, true, params, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          device.permission_for(developer).update! privilege: 1
-          device.permission_for(developer).update! bypass_delay: false
-          get :index, params
-          expect(res_hash.size).to be(1)
-          expect(res_hash.first['id']).to be(historic_checkin.id)
+          call_checkin_method('index', 1, false, params, 1, historic_checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 2 checkins" do
-          device.permission_for(developer).update! privilege: 2
-          device.permission_for(developer).update! bypass_delay: true
-          get :index, params
-          expect(res_hash.size).to be(2)
+          call_checkin_method('index', 2, true, params, 2, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          device.permission_for(developer).update! privilege: 2
-          device.permission_for(developer).update! bypass_delay: false
-          get :index, params
-          expect(res_hash.size).to be(1)
-          expect(res_hash.first['id']).to be(historic_checkin.id)
+          call_checkin_method('index', 2, false, params, 1, historic_checkin)
         end
       end
     end

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -30,38 +30,38 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          ['last', 'index'].each { |method| call_checkin_method(method, 0, false, 0, nil) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 0, false, 0, nil) }
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          ['last', 'index'].each { |method| call_checkin_method(method, 0, true, 0, nil) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 0, true, 0, nil) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          ['last', 'index'].each { |method| call_checkin_method(method, 1, true, 1, checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 1, true, 1, checkin) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          ['last', 'index'].each { |method| call_checkin_method(method, 1, false, 1, historic_checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 1, false, 1, historic_checkin) }
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 new checkin for last and 2 checkins for index" do
-          call_checkin_method('last', 2, true, 1, checkin)
-          call_checkin_method('index', 2, true, 2, checkin)
+          call_checkin_action('last', 2, true, 1, checkin)
+          call_checkin_action('index', 2, true, 2, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          ['last', 'index'].each { |method| call_checkin_method(method, 2, false, 1, historic_checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 2, false, 1, historic_checkin) }
         end
       end
     end
@@ -77,37 +77,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, false, 0, nil)
+          call_checkin_action('last', 0, false, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, true, 0, nil)
+          call_checkin_action('last', 0, true, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('last', 1, true, 1, checkin)
+          call_checkin_action('last', 1, true, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 1, false, 0, nil)
+          call_checkin_action('last', 1, false, 0, nil)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 checkin" do
-          call_checkin_method('last', 2, true, 1, checkin)
+          call_checkin_action('last', 2, true, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 2, false, 0, nil)
+          call_checkin_action('last', 2, false, 0, nil)
         end
       end
 

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     Approval.accept(user,developer,'Developer')
   end
 
-  describe "GET #last" do
-
-    context 'with 2 checkins: 1 old, 1 new.' do
-      before do
+  context 'with 2 checkins: 1 old, 1 new' do
+    before do
         historic_checkin
         checkin
-      end
+    end
+
+    describe "GET #last" do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
@@ -65,11 +65,53 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       end
     end
 
-    context 'with 1 new checkin' do
+    describe "GET #index" do
 
-      before do
-        checkin
+      context "with privilege set to disallowed and bypass_delay set to false" do
+        it "should return 0 checkins" do
+          call_checkin_method('index', 0, false, 0, nil)
+        end
       end
+
+      context "with privilege set to disallowed and bypass_delay set to true" do
+        it "should return 0 checkins" do
+          call_checkin_method('index', 0, true, 0, nil)
+        end
+      end
+
+      context "with privilege set to last_only and bypass_delay set to true" do
+        it "should return 1 new checkin" do
+          call_checkin_method('index', 1, true, 1, checkin)
+        end
+      end
+
+      context "with privilege set to last_only and bypass_delay set to false" do
+        it "should return 1 old checkin" do
+          call_checkin_method('index', 1, false, 1, historic_checkin)
+        end
+      end
+
+      context "with privilege set to complete and bypass_delay set to true" do
+        it "should return 2 checkins" do
+          call_checkin_method('index', 2, true, 2, checkin)
+        end
+      end
+
+      context "with privilege set to complete and bypass_delay set to false" do
+        it "should return 1 old checkin" do
+          call_checkin_method('index', 2, false, 1, historic_checkin)
+        end
+      end
+    end
+  end
+
+  context 'with 1 new checkin' do
+
+    before do
+      checkin
+    end
+
+    describe "GET #last" do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
@@ -108,53 +150,6 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         end
       end
 
-    end
-
-  end
-
-  describe "GET #index" do
-
-    context 'with 2 checkins: 1 old, 1 new.' do
-      before do
-        historic_checkin
-        checkin
-      end
-
-      context "with privilege set to disallowed and bypass_delay set to false" do
-        it "should return 0 checkins" do
-          call_checkin_method('index', 0, false, 0, nil)
-        end
-      end
-
-      context "with privilege set to disallowed and bypass_delay set to true" do
-        it "should return 0 checkins" do
-          call_checkin_method('index', 0, true, 0, nil)
-        end
-      end
-
-      context "with privilege set to last_only and bypass_delay set to true" do
-        it "should return 1 new checkin" do
-          call_checkin_method('index', 1, true, 1, checkin)
-        end
-      end
-
-      context "with privilege set to last_only and bypass_delay set to false" do
-        it "should return 1 old checkin" do
-          call_checkin_method('index', 1, false, 1, historic_checkin)
-        end
-      end
-
-      context "with privilege set to complete and bypass_delay set to true" do
-        it "should return 2 checkins" do
-          call_checkin_method('index', 2, true, 2, checkin)
-        end
-      end
-
-      context "with privilege set to complete and bypass_delay set to false" do
-        it "should return 1 old checkin" do
-          call_checkin_method('index', 2, false, 1, historic_checkin)
-        end
-      end
     end
 
   end

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -26,80 +26,42 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         checkin
     end
 
-    describe "GET #last" do
+    describe "GET #last/#index" do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, false, 0, nil)
+          ['last', 'index'].each { |method| call_checkin_method(method, 0, false, 0, nil) }
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, true, 0, nil)
+          ['last', 'index'].each { |method| call_checkin_method(method, 0, true, 0, nil) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('last', 1, true, 1, checkin)
+          ['last', 'index'].each { |method| call_checkin_method(method, 1, true, 1, checkin) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('last', 1, false, 1, historic_checkin)
+          ['last', 'index'].each { |method| call_checkin_method(method, 1, false, 1, historic_checkin) }
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
-        it "should return 1 new checkin" do
+        it "should return 1 new checkin for last and 2 checkins for index" do
           call_checkin_method('last', 2, true, 1, checkin)
-        end
-      end
-
-      context "with privilege set to complete and bypass_delay set to false" do
-        it "should return 1 old checkin" do
-          call_checkin_method('last', 2, false, 1, historic_checkin)
-        end
-      end
-    end
-
-    describe "GET #index" do
-
-      context "with privilege set to disallowed and bypass_delay set to false" do
-        it "should return 0 checkins" do
-          call_checkin_method('index', 0, false, 0, nil)
-        end
-      end
-
-      context "with privilege set to disallowed and bypass_delay set to true" do
-        it "should return 0 checkins" do
-          call_checkin_method('index', 0, true, 0, nil)
-        end
-      end
-
-      context "with privilege set to last_only and bypass_delay set to true" do
-        it "should return 1 new checkin" do
-          call_checkin_method('index', 1, true, 1, checkin)
-        end
-      end
-
-      context "with privilege set to last_only and bypass_delay set to false" do
-        it "should return 1 old checkin" do
-          call_checkin_method('index', 1, false, 1, historic_checkin)
-        end
-      end
-
-      context "with privilege set to complete and bypass_delay set to true" do
-        it "should return 2 checkins" do
           call_checkin_method('index', 2, true, 2, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('index', 2, false, 1, historic_checkin)
+          ['last', 'index'].each { |method| call_checkin_method(method, 2, false, 1, historic_checkin) }
         end
       end
     end
@@ -116,7 +78,6 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
           call_checkin_method('last', 0, false, 0, nil)
-
         end
       end
 

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -30,37 +30,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, false, params, 0, nil)
+          call_checkin_method('last', 0, false, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, true, params, 0, nil)
+          call_checkin_method('last', 0, true, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('last', 1, true, params, 1, checkin)
+          call_checkin_method('last', 1, true, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('last', 1, false, params, 1, historic_checkin)
+          call_checkin_method('last', 1, false, 1, historic_checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('last', 2, true, params, 1, checkin)
+          call_checkin_method('last', 2, true, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('last', 2, false, params, 1, historic_checkin)
+          call_checkin_method('last', 2, false, 1, historic_checkin)
         end
       end
     end
@@ -73,38 +73,38 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, false, params, 0, nil)
+          call_checkin_method('last', 0, false, 0, nil)
 
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 0, true, params, 0, nil)
+          call_checkin_method('last', 0, true, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('last', 1, true, params, 1, checkin)
+          call_checkin_method('last', 1, true, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 1, false, params, 0, nil)
+          call_checkin_method('last', 1, false, 0, nil)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 checkin" do
-          call_checkin_method('last', 2, true, params, 1, checkin)
+          call_checkin_method('last', 2, true, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('last', 2, false, params, 0, nil)
+          call_checkin_method('last', 2, false, 0, nil)
         end
       end
 
@@ -122,37 +122,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_method('index', 0, false, params, 0, nil)
+          call_checkin_method('index', 0, false, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_method('index', 0, true, params, 0, nil)
+          call_checkin_method('index', 0, true, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_method('index', 1, true, params, 1, checkin)
+          call_checkin_method('index', 1, true, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('index', 1, false, params, 1, historic_checkin)
+          call_checkin_method('index', 1, false, 1, historic_checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 2 checkins" do
-          call_checkin_method('index', 2, true, params, 2, checkin)
+          call_checkin_method('index', 2, true, 2, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          call_checkin_method('index', 2, false, params, 1, historic_checkin)
+          call_checkin_method('index', 2, false, 1, historic_checkin)
         end
       end
     end

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -30,38 +30,38 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 0, false, 0, nil) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 'disallowed', false, 0, nil) }
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 0, true, 0, nil) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 'disallowed', true, 0, nil) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 1, true, 1, checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 'last_only', true, 1, checkin) }
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 1, false, 1, historic_checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 'last_only', false, 1, historic_checkin) }
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 new checkin for last and 2 checkins for index" do
-          call_checkin_action('last', 2, true, 1, checkin)
-          call_checkin_action('index', 2, true, 2, checkin)
+          call_checkin_action('last', 'complete', true, 1, checkin)
+          call_checkin_action('index', 'complete', true, 2, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 2, false, 1, historic_checkin) }
+          ['last', 'index'].each { |method| call_checkin_action(method, 'complete', false, 1, historic_checkin) }
         end
       end
     end
@@ -77,37 +77,37 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to disallowed and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_action('last', 0, false, 0, nil)
+          call_checkin_action('last', 'disallowed', false, 0, nil)
         end
       end
 
       context "with privilege set to disallowed and bypass_delay set to true" do
         it "should return 0 checkins" do
-          call_checkin_action('last', 0, true, 0, nil)
+          call_checkin_action('last', 'disallowed', true, 0, nil)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to true" do
         it "should return 1 new checkin" do
-          call_checkin_action('last', 1, true, 1, checkin)
+          call_checkin_action('last', 'last_only', true, 1, checkin)
         end
       end
 
       context "with privilege set to last_only and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_action('last', 1, false, 0, nil)
+          call_checkin_action('last', 'last_only', false, 0, nil)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to true" do
         it "should return 1 checkin" do
-          call_checkin_action('last', 2, true, 1, checkin)
+          call_checkin_action('last', 'complete', true, 1, checkin)
         end
       end
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 0 checkins" do
-          call_checkin_action('last', 2, false, 0, nil)
+          call_checkin_action('last', 'complete', false, 0, nil)
         end
       end
 

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Users::Devise::RegistrationsController, type: :controller do
 
   include ControllerMacros
+  let(:user){ create_user }
 
   before do
     request.headers['X-Secret-App-Key'] = "this-is-a-mobile-app"
@@ -41,7 +42,6 @@ RSpec.describe Users::Devise::RegistrationsController, type: :controller do
   end
 
   describe 'destroy' do
-    let (:user){ create_user }
 
     context 'with a password' do
       it 'should destroy the user' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,24 +38,18 @@ RSpec.describe ApplicationHelper, :type => :helper do
   end
 
   describe '#render_flash' do
-    it 'should render an alert as a toast notification' do
-      flash[:alert] = Faker::Lorem.sentence
-      expect{ helper.render_flash }.not_to raise_error
-      expect(helper.render_flash).to match(flash[:alert])
-      expect(helper.render_flash.length).to be > flash[:alert].length
+    it 'should render an alert and a notice as a toast notification' do
+      [:alert, :notice].each do |type|
+        flash[type] = Faker::Lorem.sentence
+        expect{ helper.render_flash }.not_to raise_error
+        expect(helper.render_flash).to match(flash[type])
+        expect(helper.render_flash.length).to be > flash[type].length
 
-      # Make sure the alert is being marked for discard after rendering
-      # Otherwise the toast will appear on every subsequent page
+        # Make sure the alert is being marked for discard after rendering
+        # Otherwise the toast will appear on every subsequent page
 
-      expect(flash.instance_values['discard'].instance_values['hash'].keys.include? 'alert').to be true
-    end
-
-    it 'should render a notice as a toast notification' do
-      flash[:notice] = Faker::Lorem.sentence
-      expect{ helper.render_flash }.not_to raise_error
-      expect(helper.render_flash).to match(flash[:notice])
-      expect(helper.render_flash.length).to be > flash[:notice].length
-      expect(flash.instance_values['discard'].instance_values['hash'].keys.include? 'notice').to be true
+        expect(flash.instance_values['discard'].instance_values['hash'].keys.include? type.to_s).to be true
+      end
     end
 
     it 'should render a bunch of error messages in the flash as toasts' do

--- a/spec/support/checkins_spec_helpers.rb
+++ b/spec/support/checkins_spec_helpers.rb
@@ -1,11 +1,18 @@
 module CheckinsSpecHelpers
 
-  def call_last(priv, delay, params, number, checkin)
+  def call_checkin_method(method, priv, delay, params, number, checkin)
     device.permission_for(developer).update! privilege: priv
     device.permission_for(developer).update! bypass_delay: delay
-    get :last, params
+    get method.to_sym, params
     expect(res_hash.size).to be number
     expect(res_hash.first['id']).to be(checkin.id) if checkin
   end
 
+  def call_index(priv, delay, params, number, checkin)
+    device.permission_for(developer).update! privilege: priv
+    device.permission_for(developer).update! bypass_delay: delay
+    get :index, params
+    expect(res_hash.size).to be number
+    expect(res_hash.first['id']).to be(checkin.id) if checkin
+  end
 end

--- a/spec/support/checkins_spec_helpers.rb
+++ b/spec/support/checkins_spec_helpers.rb
@@ -1,6 +1,6 @@
 module CheckinsSpecHelpers
 
-  def call_checkin_method(method, priv, delay, params, number, checkin)
+  def call_checkin_method(method, priv, delay, number, checkin)
     device.permission_for(developer).update! privilege: priv
     device.permission_for(developer).update! bypass_delay: delay
     get method.to_sym, params
@@ -8,11 +8,4 @@ module CheckinsSpecHelpers
     expect(res_hash.first['id']).to be(checkin.id) if checkin
   end
 
-  def call_index(priv, delay, params, number, checkin)
-    device.permission_for(developer).update! privilege: priv
-    device.permission_for(developer).update! bypass_delay: delay
-    get :index, params
-    expect(res_hash.size).to be number
-    expect(res_hash.first['id']).to be(checkin.id) if checkin
-  end
 end

--- a/spec/support/checkins_spec_helpers.rb
+++ b/spec/support/checkins_spec_helpers.rb
@@ -1,6 +1,6 @@
 module CheckinsSpecHelpers
 
-  def call_checkin_method(method, priv, delay, number, checkin)
+  def call_checkin_action(method, priv, delay, number, checkin)
     device.permission_for(developer).update! privilege: priv
     device.permission_for(developer).update! bypass_delay: delay
     get method.to_sym, params

--- a/spec/support/checkins_spec_helpers.rb
+++ b/spec/support/checkins_spec_helpers.rb
@@ -1,0 +1,11 @@
+module CheckinsSpecHelpers
+
+  def call_last(priv, delay, params, number, checkin)
+    device.permission_for(developer).update! privilege: priv
+    device.permission_for(developer).update! bypass_delay: delay
+    get :last, params
+    expect(res_hash.size).to be number
+    expect(res_hash.first['id']).to be(checkin.id) if checkin
+  end
+
+end


### PR DESCRIPTION
wrote a helper method call_checkin_action which takes the action, privilege level, bypass_delay setting, number of checkins expected to be returned and first checkin expected to be returned.