### PR TITLE
Api checkins app

### DIFF
--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -7,21 +7,19 @@ class Api::V1::CheckinsController < Api::ApiController
 
   def index
     if req_from_coposition_app?
-      checkins = app_index_checkins
+      checkins = copo_app_checkins
     else
       params[:per_page].to_i <= 1000 ? per_page = params[:per_page] : per_page = 1000
       checkins = @user.get_checkins(@permissible, @device).paginate(page: params[:page], per_page: per_page)
       paginated_response_headers(checkins)
-      checkins = checkins.includes(:device).map do |checkin|
-        checkin.resolve_address(@permissible, params[:type])
-      end
+      checkins = checkins.resolve_address(@permissible, params[:type])
     end
     render json: checkins
   end
 
   def last
     if req_from_coposition_app?
-      checkin = app_last_checkin
+      checkin = copo_app_checkin
     else
       checkin = @user.get_checkins(@permissible, @device).first
       checkin = checkin.resolve_address(@permissible, params[:type]) if checkin
@@ -57,7 +55,7 @@ class Api::V1::CheckinsController < Api::ApiController
       if params[:device_id] then @device = Device.find(params[:device_id]) end
     end
 
-    def app_index_checkins
+    def copo_app_checkins
       checkins = @device ? @device.checkins : @user.checkins
       checkins = checkins.includes(:device).map do |checkin|
         checkin.reverse_geocode!
@@ -65,7 +63,7 @@ class Api::V1::CheckinsController < Api::ApiController
       checkins
     end
 
-    def app_last_checkin
+    def copo_app_checkin
       checkins = @device ? @device.checkins : @user.checkins
       if checkins
         checkin = checkins.first

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -94,6 +94,12 @@ class Checkin < ActiveRecord::Base
     self.public_info
   end
 
+  def self.resolve_address(permissible, type)
+    includes(:device).map do |checkin|
+      checkin.resolve_address(permissible, type)
+    end
+  end
+
   def self.hash_group_and_count_by(attribute)
     select(&attribute).group_by(&attribute)
     .each_with_object({}) do |(key,checkins), result|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,6 @@ Rails.application.routes.draw do
         end
         resources :checkins, only: [:index] do
           collection do
-            get :app_index
             get :last
           end
         end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -148,33 +148,6 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     end
   end
 
-  describe "GET #app_index" do
-    context "with the secret app key" do
-      before do
-        request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
-        checkin
-      end
-
-      it "should fetch the user's device checkins" do
-        get :app_index, params
-        expect(res_hash.first['id']).to be checkin.id
-      end
-
-      it "should geocode checkins if type param provided" do
-        get :app_index, params.merge(type: "address")
-        expect(res_hash.first['city']).to eq 'Denham'
-      end
-    end
-
-    context "without secret app key" do
-      it "should return an error message" do
-        checkin
-        get :app_index, params
-        expect(res_hash[:message]).to match "You must supply the secret app key"
-      end
-    end
-  end
-
   describe "POST #create" do
 
     it "should create a checkin when there is a pre-existing device" do

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     end
   end
 
+  shared_context "from copo app" do
+    before do
+      request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
+      checkin
+    end
+  end
+
   describe "GET #last" do
     context "without developer approval" do
       it "shouldn't fetch the last reported location", :skip_before do
@@ -104,18 +111,15 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     end
 
     context "from coposition app" do
-      before do
-        request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
-        checkin
-      end
+      include_context "from copo app"
 
-      it "should fetch the user's device checkins with all attributes" do
+      it "should fetch the user's last device checkin with all attributes" do
         get :last, params
         expect(res_hash.first['id']).to be checkin.id
         expect(res_hash.first.keys).to eq checkin.attributes.keys
       end
 
-      it "should geocode checkins if type param provided" do
+      it "should geocode last checkin if type param provided" do
         get :last, params.merge(type: "address")
         expect(res_hash.first['city']).to eq 'Denham'
       end
@@ -166,18 +170,15 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     end
 
     context "from coposition app" do
-      before do
-        request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
-        checkin
-      end
+      include_context "from copo app"
 
-      it "should fetch the user's device checkins" do
+      it "should fetch all the user's device checkins" do
         get :index, params
         expect(res_hash.first['id']).to be checkin.id
         expect(res_hash.first.keys).to eq checkin.attributes.keys
       end
 
-      it "should geocode checkins if type param provided" do
+      it "should geocode all checkins if type param provided" do
         get :index, params.merge(type: "address")
         expect(res_hash.first['city']).to eq 'Denham'
       end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         expect(res_hash.first['lat']).to be_within(0.00001).of(checkin.lat)
       end
     end
+
+    context "from coposition app" do
+      before do
+        request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
+        checkin
+      end
+
+      it "should fetch the user's device checkins with all attributes" do
+        get :last, params
+        expect(res_hash.first['id']).to be checkin.id
+        expect(res_hash.first.keys).to eq checkin.attributes.keys
+      end
+
+      it "should geocode checkins if type param provided" do
+        get :last, params.merge(type: "address")
+        expect(res_hash.first['city']).to eq 'Denham'
+      end
+    end
   end
 
   describe "GET #index when the device has 31 checkins" do
@@ -144,6 +162,24 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       it "should fetch the most recent checkins (up to 30 checkins)" do
         get :index, { user_id: user.id }
         expect(res_hash.first['id']).to be device.checkins.first.id
+      end
+    end
+
+    context "from coposition app" do
+      before do
+        request.headers["X-Secret-App-Key"] = 'this-is-a-mobile-app'
+        checkin
+      end
+
+      it "should fetch the user's device checkins" do
+        get :index, params
+        expect(res_hash.first['id']).to be checkin.id
+        expect(res_hash.first.keys).to eq checkin.attributes.keys
+      end
+
+      it "should geocode checkins if type param provided" do
+        get :index, params.merge(type: "address")
+        expect(res_hash.first['city']).to eq 'Denham'
       end
     end
   end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -169,18 +169,18 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       end
     end
 
-    context "from coposition app" do
+    context "copo mobile app" do
       include_context "from copo app"
 
       it "should fetch all the user's device checkins" do
         get :index, params
-        expect(res_hash.first['id']).to be checkin.id
         expect(res_hash.first.keys).to eq checkin.attributes.keys
+        expect(res_hash.first['id']).to be checkin.id
       end
 
       it "should geocode all checkins if type param provided" do
         get :index, params.merge(type: "address")
-        expect(res_hash.first['city']).to eq 'Denham'
+        expect(res_hash.first['address']).to match 'The Pilot Centre'
       end
     end
   end


### PR DESCRIPTION
Removed extra app_index action for the copo app getting checkins and just moved a check to see if request is coming from copo app in the regular index/last actions.

If request is from app, just gets checkins with no filters/restrictions, else, does the usual permitted history, fogging, privilege level checks etc.

Think this is an improvement but not sure if actions are too complicated now, still under 10 lines thankfully.