### PR TITLE
API Device/User checkins routing was broken.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,11 +55,6 @@ Rails.application.routes.draw do
           end
         end
         resources :devices, only: [:index, :create, :show, :update], module: :users do
-          resources :checkins, only: [:index] do
-            collection do
-              get :last
-            end
-          end
           resources :permissions, only: [:update, :index]
           put '/permissions', to: 'permissions#update_all'
         end


### PR DESCRIPTION
The routes have to match the controller exactly, route for getting a device's checkins was namespaced under users + devices but controller did not match this so if you got a user's checkins then tried to get a specific device's checkins, you would get a routing error.

Could create new controller but this would be a lot of duplication, think it makes more sense to remove device route and if you want a specific device checkins you supply the device_id as a query string param.

e.g. users/2/checkins?device_id=5 instead of /users/2/devices/5/checkins