### PR TITLE
Codeclimate peace offering

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -106,8 +106,7 @@ window.COPO.charts = {
       data.addColumn('string');
       checkins.forEach(function(checkin){
         var humanizedDate = moment(checkin.created_at).format('LLL');
-        var foggedClass;
-        checkin.fogged ? foggedClass = 'fogged enabled-icon' : foggedClass = ' disabled-icon';
+        var foggedClass = checkin.fogged ?  'fogged enabled-icon' : ' disabled-icon';
         var delete_button = COPO.utility.deleteCheckinLink(checkin);
         var fogging_button = COPO.utility.fogCheckinLink(checkin, foggedClass, 'tableFog');
         tableData.push([

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -1,3 +1,5 @@
+/*eslint no-unused-expressions: [2, { allowTernary: true }]*/
+
 window.COPO = window.COPO || {};
 window.COPO.charts = {
   drawBarChart: function(checkins, height, page) {

--- a/app/assets/javascripts/devices/devices-shared.js
+++ b/app/assets/javascripts/devices/devices-shared.js
@@ -4,16 +4,19 @@ $(document).on('page:change', function() {
     COPO.maps.initMap()
     COPO.maps.initControls();
     var checkin = gon.checkin;
+    var avatar;
+    var template;
+    var rendered;
 
     if(!checkin) {
-      var avatar = COPO.utility.avatar(gon.user.avatar, {class: 'left'});
+      avatar = COPO.utility.avatar(gon.user.avatar, {class: 'left'});
       var friend = {
         name: COPO.utility.friendsName(gon.user),
         device: gon.device,
         avatar: avatar
        }
-      var template = $('#nullPopupTemplate').html();
-      var rendered = Mustache.render(template, friend);
+      template = $('#nullPopupTemplate').html();
+      rendered = Mustache.render(template, friend);
 
       var popup = L.popup({'closeButton': false, 'closeOnClick': false})
         .setLatLng(new L.latLng([51.5073509, -0.1277583])) //hardcoded latlng for London
@@ -23,7 +26,7 @@ $(document).on('page:change', function() {
         map.panTo(popup.getLatLng());
       })
     } else {
-      var avatar = COPO.utility.avatar(gon.user.avatar);
+      avatar = COPO.utility.avatar(gon.user.avatar);
       $.extend(checkin, {
         avatar: avatar,
         created_at: new Date(checkin.created_at).toUTCString(),
@@ -32,8 +35,8 @@ $(document).on('page:change', function() {
         friend: COPO.utility.friendsName(gon.user)
       })
 
-      var template = $('#fullPopupTemplate').html();
-      var rendered = Mustache.render(template, checkin);
+      template = $('#fullPopupTemplate').html();
+      rendered = Mustache.render(template, checkin);
 
       map.setView([checkin.lat, checkin.lng], 12)
       var marker = L.marker([checkin.lat, checkin.lng], {

--- a/app/assets/javascripts/devices/devices-shared.js
+++ b/app/assets/javascripts/devices/devices-shared.js
@@ -4,9 +4,7 @@ $(document).on('page:change', function() {
     COPO.maps.initMap()
     COPO.maps.initControls();
     var checkin = gon.checkin;
-    var avatar;
-    var template;
-    var rendered;
+    var avatar, template, rendered;
 
     if(!checkin) {
       avatar = COPO.utility.avatar(gon.user.avatar, {class: 'left'});

--- a/app/assets/javascripts/landing-page.js
+++ b/app/assets/javascripts/landing-page.js
@@ -18,10 +18,10 @@ $(document).on('ready page:change', function() {
       var $currOffset = $(window).scrollTop();
       var winHeight = window.innerHeight;
 
-      if($currOffset >= winHeight && $(".contents-menu").css('position') != "fixed"){
+      if($currOffset >= winHeight && $(".contents-menu").css('position') !== "fixed"){
         $(".contents-menu").css('position', 'fixed');
 
-      }else if($currOffset < winHeight && $(".contents-menu").css('position') == "fixed"){
+      }else if($currOffset < winHeight && $(".contents-menu").css('position') === "fixed"){
         $(".contents-menu").css('position', 'relative');
       }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,20 +70,6 @@ class User < ActiveRecord::Base
       end
     end
   end
-=begin
-    if permissible.class.to_s == 'Developer'
-      dev_devices = devices.includes(:developers)
-      dev_devices.each do |device|
-        device.developers << permissible unless device.developers.include? permissible
-      end
-    else
-      usr_devices = devices.includes(:permitted_users)
-      usr_devices.each do |device|
-        device.permitted_users << permissible unless device.permitted_users.include? permissible
-      end
-    end
-  end
-=end
 
   ## Checkins
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ActiveRecord::Base
   ## Devices
 
   def approve_devices(permissible)
-    devices.each do |device|
+    devices.includes(:developers, :permitted_users).each do |device|
       if permissible.class.to_s == 'Developer'
         device.developers << permissible unless device.developers.include? permissible
       else
@@ -84,8 +84,6 @@ class User < ActiveRecord::Base
     end
   end
 =end
-
-  def add_permissible
 
   ## Checkins
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,15 @@ class User < ActiveRecord::Base
   ## Devices
 
   def approve_devices(permissible)
+    devices.each do |device|
+      if permissible.class.to_s == 'Developer'
+        device.developers << permissible unless device.developers.include? permissible
+      else
+        device.permitted_users << permissible unless device.permitted_users.include? permissible
+      end
+    end
+  end
+=begin
     if permissible.class.to_s == 'Developer'
       dev_devices = devices.includes(:developers)
       dev_devices.each do |device|
@@ -74,6 +83,9 @@ class User < ActiveRecord::Base
       end
     end
   end
+=end
+
+  def add_permissible
 
   ## Checkins
 

--- a/lib/tasks/avatars.rake
+++ b/lib/tasks/avatars.rake
@@ -2,7 +2,7 @@ namespace :avatars do
 require 'pp'
 
   desc "Adds a random avatar to a user."
-  task :user, [:id]  => :environment do |t, args|
+  task :user, [:id]  => :environment do |_t, args|
     validate_id(args)
     user = User.find_by(id: args[:id])
     set_avatar(user)
@@ -18,7 +18,7 @@ require 'pp'
   end
 
   desc "Adds a random avatar to an app/developer."
-  task :app, [:id]  => :environment do |t, args|
+  task :app, [:id]  => :environment do |_t, args|
     validate_id(args)
     app = Developer.find_by(id: args[:id])
     set_avatar(app)

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
       context "with privilege set to complete and bypass_delay set to false" do
         it "should return 1 old checkin" do
-          ['last', 'index'].each { |method| call_checkin_action(method, 'complete', false, 1, historic_checkin) }
+          ['index', 'last'].each { |action| call_checkin_action(action, 'complete', false, 1, historic_checkin) }
         end
       end
     end

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         end
       end
 
-      context "with privilege set to complete and bypass_delay set to false" do
-        it "should return 1 old checkin" do
+      context "with bypass_delay set to false and privilege set to complete" do
+        it "should return the historic checkin" do
           ['index', 'last'].each { |action| call_checkin_action(action, 'complete', false, 1, historic_checkin) }
         end
       end

--- a/spec/controllers/users/approvals_controller_spec.rb
+++ b/spec/controllers/users/approvals_controller_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Users::ApprovalsController, type: :controller do
   end
 
   describe 'GET #new' do
-    it 'should assign a new approval' do
+    it 'should assign an empty approval' do
       get :new, user_params
-      expect((assigns :approval).class).to eq Approval.new.class
+      expect((assigns :approval).model_name).to match 'Approval'
     end
   end
 

--- a/spec/helpers/approvals_helper_spec.rb
+++ b/spec/helpers/approvals_helper_spec.rb
@@ -7,15 +7,18 @@ RSpec.describe ApprovalsHelper, :type => :helper do
     user
   end
 
+  let(:user_approvals_input){ helper.approvals_input('User') }
+  let(:developer_approvals_input){ helper.approvals_input('Developer') }
+
   describe '#approvals_input' do
     it 'should assign placeholder key a string' do
-      expect(helper.approvals_input('Developer')[:placeholder]).to match 'name'
-      expect(helper.approvals_input('User')[:placeholder]).to match 'email@email.com'
+      expect(developer_approvals_input[:placeholder]).to match 'name'
+      expect(user_approvals_input[:placeholder]).to match 'email@email.com'
     end
 
     it 'should assign class key' do
-      expect(helper.approvals_input('User')[:class]).to match 'validate'
-      expect(helper.approvals_input('Developer')[:class]).to match 'devs'
+      expect(user_approvals_input[:class]).to match 'validate'
+      expect(developer_approvals_input[:class]).to match 'devs'
     end
   end
 

--- a/spec/helpers/approvals_helper_spec.rb
+++ b/spec/helpers/approvals_helper_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ApprovalsHelper, :type => :helper do
       expect(user_approvals_input[:placeholder]).to match 'email@email.com'
     end
 
-    it 'should set class key' do
-      expect(user_approvals_input[:class]).to eq 'validate'
+    it 'should assign class key' do
+      expect(user_approvals_input[:class]).to match 'validate'
       expect(developer_approvals_input[:class]).to match 'devs_typeahead'
     end
   end

--- a/spec/helpers/approvals_helper_spec.rb
+++ b/spec/helpers/approvals_helper_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe ApprovalsHelper, :type => :helper do
     user.pending_friends << [FactoryGirl::create(:user), FactoryGirl::create(:user)]
     user
   end
-
   let(:user_approvals_input){ helper.approvals_input('User') }
   let(:developer_approvals_input){ helper.approvals_input('Developer') }
 
@@ -16,9 +15,9 @@ RSpec.describe ApprovalsHelper, :type => :helper do
       expect(user_approvals_input[:placeholder]).to match 'email@email.com'
     end
 
-    it 'should assign class key' do
-      expect(user_approvals_input[:class]).to match 'validate'
-      expect(developer_approvals_input[:class]).to match 'devs'
+    it 'should set class key' do
+      expect(user_approvals_input[:class]).to eq 'validate'
+      expect(developer_approvals_input[:class]).to eq 'validate devs_typeahead'
     end
   end
 

--- a/spec/helpers/approvals_helper_spec.rb
+++ b/spec/helpers/approvals_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ApprovalsHelper, :type => :helper do
 
     it 'should set class key' do
       expect(user_approvals_input[:class]).to eq 'validate'
-      expect(developer_approvals_input[:class]).to eq 'validate devs_typeahead'
+      expect(developer_approvals_input[:class]).to match 'devs_typeahead'
     end
   end
 


### PR DESCRIPTION
Bunch of different issues fixed on codeclimate.
Fixed: Expected an assignment or function call and instead saw an expression.

Found in app/assets/javascripts/charts.js by eslint
Fixed: Expected an assignment or function call and instead saw an expression.

Found in app/assets/javascripts/charts.js by eslint
Fixed: Expected '===' and instead saw '=='.

Found in app/assets/javascripts/landing-page.js by eslint
Fixed: Expected '!==' and instead saw '!='.

Found in app/assets/javascripts/landing-page.js by eslint
Fixed: Similar code found in 1 other location (mass = 19)

Found in spec/controllers/users/approvals_controller_spec.rb
Fixed: Similar code found in 1 other location (mass = 22)

Found in spec/helpers/approvals_helper_spec.rb
Fixed: Similar code found in 1 other location (mass = 22)

Found in spec/helpers/approvals_helper_spec.rb
Fixed: Unused block argument - t. If it's necessary, use _ or _t as an argument name to indicate that it won't be used.

Found in lib/tasks/avatars.rake by rubocop
Fixed: Unused block argument - t. If it's necessary, use _ or _t as an argument name to indicate that it won't be used.

Found in lib/tasks/avatars.rake by rubocop
Fixed: Similar code found in 1 other location (mass = 19)

Found in spec/controllers/developers/approvals_controller_spec.rb
Fixed: "avatar" is already defined

Found in app/assets/javascripts/devices/devices-shared.js by eslint
Fixed: "rendered" is already defined

Found in app/assets/javascripts/devices/devices-shared.js by eslint
Fixed: "template" is already defined

Found in app/assets/javascripts/devices/devices-shared.js by eslint
Fixed: Similar code found in 1 other location (mass = 18)

Found in app/models/user.rb
Fixed: Similar code found in 1 other location (mass = 18)