### PR TITLE
Developer email zap

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,13 +1,15 @@
 class Api::V1::SubscriptionsController < ActionController::Base
   def create
-    user = User.find_by(webhook_key: request.headers['X-Webhook-Key'])
-    sub = user.subscriptions.create(allowed_params)
+    subscriber = User.find_by(webhook_key: request.headers['X-Authentication-Key'])
+    subscriber ||= Developer.find_by(api_key: request.headers['X-Authentication-Key'])
+    sub = subscriber.subscriptions.create(allowed_params)
     render status: 201, json: { id: sub.id }
   end
 
   def destroy
-    user = User.find_by(webhook_key: request.headers['X-Webhook-Key'])
-    sub = user.subscriptions.find(params[:id]).destroy
+    subscriber = User.find_by(webhook_key: request.headers['X-Authentication-Key'])
+    subscriber ||= Developer.find_by(api_key: request.headers['X-Authentication-Key'])
+    sub = subscriber.subscriptions.destroy(params[:id])
     render status: 200, json: { id: sub.id }
   end
 

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,15 +1,10 @@
 class Api::V1::SubscriptionsController < ActionController::Base
   def create
-    subscriber = User.find_by(webhook_key: request.headers['X-Authentication-Key'])
-    subscriber ||= Developer.find_by(api_key: request.headers['X-Authentication-Key'])
     sub = subscriber.subscriptions.create(allowed_params)
     render status: 201, json: { id: sub.id }
   end
 
   def destroy
-    key = request.headers['X-Authentication-Key']
-    subscriber = User.find_by(webhook_key: key)
-    subscriber ||= Developer.find_by(api_key: key)
     sub = subscriber.subscriptions.destroy(params[:id]).first
     render status: 200, json: { id: sub.id }
   end
@@ -18,5 +13,10 @@ class Api::V1::SubscriptionsController < ActionController::Base
 
   def allowed_params
     params.permit(:target_url, :event)
+  end
+
+  def subscriber
+    key = request.headers['X-Authentication-Key']
+    User.find_by(webhook_key: key) || Developer.find_by(api_key: key)
   end
 end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -7,9 +7,10 @@ class Api::V1::SubscriptionsController < ActionController::Base
   end
 
   def destroy
-    subscriber = User.find_by(webhook_key: request.headers['X-Authentication-Key'])
-    subscriber ||= Developer.find_by(api_key: request.headers['X-Authentication-Key'])
-    sub = subscriber.subscriptions.destroy(params[:id])
+    key = request.headers['X-Authentication-Key']
+    subscriber = User.find_by(webhook_key: key)
+    subscriber ||= Developer.find_by(api_key: key)
+    sub = subscriber.subscriptions.destroy(params[:id]).first
     render status: 200, json: { id: sub.id }
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -10,8 +10,9 @@ class Api::V1::UsersController < Api::ApiController
   end
 
   def auth
-    user = User.find_by(webhook_key: request.headers['X-Webhook-Key'])
-    if user
+    subscriber = User.find_by(webhook_key: request.headers['X-Authentication-Key'])
+    subscriber ||= Developer.find_by(api_key: request.headers['X-Authentication-Key'])
+    if subscriber
       render status: 204, json: { message: 'Success' }
     else
       render status: 400, json: { message: 'Invalid webhook key supplied' }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
     @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
     gon.push(@presenter.gon)
   end
+
+  def zapier_data(approval)
+    [current_user.public_info, approval]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,9 @@ class ApplicationController < ActionController::Base
   def record_not_found(exception)
     redirect_to root_path, alert: exception.message
   end
+
+  def presenter_and_gon(type)
+    @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
+    gon.push(@presenter.gon)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,12 +9,12 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: exception.message
   end
 
-  def presenter_and_gon(type)
+  def approvals_presenter_and_gon(type)
     @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
     gon.push(@presenter.gon)
   end
 
-  def zapier_data(approval)
+  def approval_zapier_data(approval)
     [current_user.public_info, approval]
   end
 end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -15,7 +15,7 @@ class Developers::ApprovalsController < ApplicationController
     user = User.find_by(email: email)
     approval = Approval.link(user, current_developer, 'Developer') if user
     approval && approval.id ? flash[:notice] = 'Successfully sent' : flash[:alert] = 'Error creating approval'
-    current_developer.notify_if_subscribed('create_approval', zapier_data(email, user))
+    current_developer.notify_if_subscribed('new_approval', zapier_data(email, user))
     redirect_to new_developers_approval_path
   end
 

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -21,7 +21,14 @@ class Developers::ApprovalsController < ApplicationController
     redirect_to new_developers_approval_path
   end
 
+  private
+
   def allowed_params
     params.require(:approval).permit(:user)
+  end
+
+  def check_subscriptions
+    if current_developer.subscriptions.where(event: 'create_approval').present?
+    end
   end
 end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -11,13 +11,11 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: allowed_params[:user])
+    email = allowed_params[:user]
+    user = User.find_by(email: email)
     approval = Approval.link(user, current_developer, 'Developer') if user
-    if approval && approval.id
-      flash[:notice] = 'Successfully sent'
-    else
-      flash[:alert] = 'Error creating approval'
-    end
+    approval && approval.id ? flash[:notice] = 'Successfully sent' : flash[:alert] = 'Error creating approval'
+    current_developer.notify_if_subscribed('create_approval', zapier_data(email, user))
     redirect_to new_developers_approval_path
   end
 
@@ -27,8 +25,10 @@ class Developers::ApprovalsController < ApplicationController
     params.require(:approval).permit(:user)
   end
 
-  def check_subscriptions
-    if current_developer.subscriptions.where(event: 'create_approval').present?
-    end
+  def zapier_data(email, user)
+    approval = user.approval_for(current_developer) if user
+    zapier_data = [email, approval]
+    zapier_data << user.public_info if user
+    zapier_data
   end
 end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -26,9 +26,8 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def zapier_data(email, user)
-    approval = user.approval_for(current_developer) if user
-    zapier_data = [email, approval]
-    zapier_data << user.public_info if user
-    zapier_data
+    zapier_data = [email: email]
+    return zapier_data unless user
+    zapier_data.push(user.public_info, user.approval_for(current_developer))
   end
 end

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -30,8 +30,10 @@ class Users::ApprovalsController < ApplicationController
   def approve
     approval = Approval.find_by(id: params[:id], user: current_user)
     approvable_type = approval.approvable_type
-    Approval.accept(current_user, approval.approvable, approvable_type)
+    approvable = approval.approvable
+    Approval.accept(current_user, approvable, approvable_type)
     presenter_and_gon(approvable_type)
+    approvable.notify_if_subscribed('new_approval', zapier_data(approval)) if approvable_type == 'Developer'
   end
 
   def reject

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -12,18 +12,18 @@ class Users::ApprovalsController < ApplicationController
     user = User.find_by(email: allowed_params[:approvable])
     approval = Approval.add_friend(current_user, user) if user
     if approval_created?(user, approval)
-      presenter_and_gon('User')
+      approvals_presenter_and_gon('User')
       redirect_to(user_friends_path, notice: 'Friend request sent')
     end
   end
 
   def apps
-    presenter_and_gon('Developer')
+    approvals_presenter_and_gon('Developer')
     render 'approvals'
   end
 
   def friends
-    presenter_and_gon('User')
+    approvals_presenter_and_gon('User')
     render 'approvals'
   end
 
@@ -32,8 +32,8 @@ class Users::ApprovalsController < ApplicationController
     approvable_type = approval.approvable_type
     approvable = approval.approvable
     Approval.accept(current_user, approvable, approvable_type)
-    presenter_and_gon(approvable_type)
-    approvable.notify_if_subscribed('new_approval', zapier_data(approval)) if approvable_type == 'Developer'
+    approvals_presenter_and_gon(approvable_type)
+    approvable.notify_if_subscribed('new_approval', approval_zapier_data(approval)) if approvable_type == 'Developer'
   end
 
   def reject
@@ -45,7 +45,7 @@ class Users::ApprovalsController < ApplicationController
       Approval.destroy_all(user: approvable, approvable: current_user, approvable_type: 'User')
     end
     approval.destroy
-    presenter_and_gon(approvable_type)
+    approvals_presenter_and_gon(approvable_type)
     render 'approve'
   end
 

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -63,9 +63,4 @@ class Users::ApprovalsController < ApplicationController
     end
     false
   end
-
-  def presenter_and_gon(type)
-    @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
-    gon.push(@presenter.gon)
-  end
 end

--- a/app/controllers/users/create_dev_approvals_controller.rb
+++ b/app/controllers/users/create_dev_approvals_controller.rb
@@ -5,8 +5,8 @@ class Users::CreateDevApprovalsController < ApplicationController
     developer = Developer.find_by(company_name: allowed_params[:approvable])
     approval = Approval.add_developer(current_user, developer) if developer
     return unless approval_created?(developer, approval)
-    presenter_and_gon('Developer')
-    developer.notify_if_subscribed('new_approval', zapier_data(approval))
+    approvals_presenter_and_gon('Developer')
+    developer.notify_if_subscribed('new_approval', approval_zapier_data(approval))
     redirect_to(user_apps_path, notice: 'Developer approved')
   end
 

--- a/app/controllers/users/create_dev_approvals_controller.rb
+++ b/app/controllers/users/create_dev_approvals_controller.rb
@@ -22,8 +22,4 @@ class Users::CreateDevApprovalsController < ApplicationController
     redirect_to new_user_approval_path(approvable_type: 'Developer'), alert: "Error: #{errors}"
     false
   end
-
-  def zapier_data(approval)
-    [current_user.public_info, approval]
-  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,10 +4,9 @@ class UserMailer < ApplicationMailer
     mail(to: address, subject: 'Coposition invite')
   end
 
-  def add_user_email(from, added_user, developer)
-    @url = "https://coposition.com/users/#{added_user.id}/"
-    @url += developer ? 'apps' : 'friends'
-    @from = developer ? from.company_name : from.email
-    mail(to: added_user.email, subject: "Coposition approval request from #{@from}")
+  def add_user_email(approvable, user, from_developer)
+    @url = "https://coposition.com/users/#{user.id}/#{from_developer ? 'apps' : 'friends'}"
+    @from = from_developer ? approvable.company_name : approvable.email
+    mail(to: user.email, subject: "Coposition approval request from #{@from}")
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,8 +5,8 @@ class UserMailer < ApplicationMailer
   end
 
   def add_user_email(from, added_user, developer)
-    base_url = "https://coposition.com/users/#{added_user.id}/"
-    @url = developer ? base_url + 'apps' : base_url + 'friends'
+    @url = "https://coposition.com/users/#{added_user.id}/"
+    @url += developer ? 'apps' : 'friends'
     @from = developer ? from.company_name : from.email
     mail(to: added_user.email, subject: "Coposition approval request from #{@from}")
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,4 +9,10 @@ class UserMailer < ApplicationMailer
     @email = user.email
     mail(to: friend.email, subject: "Coposition friend request from #{@email}")
   end
+
+  def add_user_email(developer, user)
+    @url = "https://coposition.com/users/#{user.id}/apps"
+    @company_name = developer.company_name
+    mail(to: user.email, subject: "Coposition approval request from #{@company_name}")
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,15 +4,10 @@ class UserMailer < ApplicationMailer
     mail(to: address, subject: 'Coposition invite')
   end
 
-  def add_friend_email(user, friend)
-    @url = "https://coposition.com/users/#{friend.id}/friends"
-    @email = user.email
-    mail(to: friend.email, subject: "Coposition friend request from #{@email}")
-  end
-
-  def add_user_email(developer, user)
-    @url = "https://coposition.com/users/#{user.id}/apps"
-    @company_name = developer.company_name
-    mail(to: user.email, subject: "Coposition approval request from #{@company_name}")
+  def add_user_email(from, added_user, developer)
+    base_url = "https://coposition.com/users/#{added_user.id}/"
+    @url = developer ? base_url + 'apps' : base_url + 'friends'
+    @from = developer ? from.company_name : from.email
+    mail(to: added_user.email, subject: "Coposition approval request from #{@from}")
   end
 end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -17,7 +17,7 @@ class Approval < ActiveRecord::Base
     if (approvable_type == 'Developer') || user.friend_requests.include?(approvable)
       approval = Approval.accept(user, approvable, approvable_type)
     else
-      UserMailer.add_friend_email(user, approvable).deliver_now unless approval.errors.messages.present?
+      UserMailer.add_user_email(user, approvable, false).deliver_now unless approval.errors.messages.present?
     end
     approval
   end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -25,7 +25,7 @@ class Approval < ActiveRecord::Base
     if user.request_from?(friend)
       approval = Approval.accept(user, friend, 'User')
     else
-      UserMailer.add_user_email(user, approvable, false).deliver_now unless approval.errors.messages.present?
+      UserMailer.add_user_email(user, friend, false).deliver_now unless approval.errors.messages.present?
     end
     approval
   end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -10,7 +10,7 @@ class Developer < ActiveRecord::Base
   has_many :requests, dependent: :destroy
   has_many :permissions, as: :permissible, dependent: :destroy
   has_many :devices, through: :permissions
-
+  has_many :subscriptions, as: :subscriber, dependent: :destroy
   has_many :approvals, as: :approvable, dependent: :destroy
   has_many :pending_requests, -> { where "status = 'developer-requested'" }, through: :approvals, source: :user
   has_many :users, -> { where "status = 'accepted'" }, through: :approvals

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -26,4 +26,13 @@ class Developer < ActiveRecord::Base
   def public_info
     Developer.select([:id, :email, :company_name, :tagline, :redirect_url]).find(id)
   end
+
+  def subscribed_to?(event)
+    subscriptions.find_by(event: event)
+  end
+
+  def notify_if_subscribed(event, data)
+    return unless (sub = subscribed_to? event)
+    sub.send_data(data)
+  end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -76,7 +76,7 @@ class Device < ActiveRecord::Base
   end
 
   def subscriptions(event)
-    Subscription.where(event: event).where(user_id: user_id)
+    Subscription.where(event: event).where(subscriber_id: user_id)
   end
 
   def notify_subscribers(event, data)

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 class Subscription < ActiveRecord::Base
   require 'net/http'
 
-  belongs_to :user
+  belongs_to :subscriber, polymorphic: true
 
   def send_data(data)
     uri = URI.parse('https://zapier.com/')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
   has_many :checkins, through: :devices
   has_many :requests
   has_many :approvals, dependent: :destroy
-  has_many :subscriptions, dependent: :destroy
+  has_many :subscriptions, as: :subscriber, dependent: :destroy
   has_many :developers, -> { where "status = 'accepted'" },
            through: :approvals, source: :approvable, source_type: 'Developer'
   has_many :friends, -> { where "status = 'accepted'" },

--- a/app/views/user_mailer/add_friend_email.html.erb
+++ b/app/views/user_mailer/add_friend_email.html.erb
@@ -1,8 +1,0 @@
-<h1>Hi there!</h1>
-<p>
-  <%= @email %> has sent you a friend request on Coposition!<br>
-</p>
-<p>
-  To respond, just follow this link: <%= @url %>
-</p>
-<p>Coposition Support</p>

--- a/app/views/user_mailer/add_friend_email.text.erb
+++ b/app/views/user_mailer/add_friend_email.text.erb
@@ -1,7 +1,0 @@
-Hi there!
-
-<%= @email %> has sent you a friend request on Coposition!<br>
-
-To respond, just follow this link: <%= @url %>
-
-Coposition Support

--- a/app/views/user_mailer/add_user_email.html.erb
+++ b/app/views/user_mailer/add_user_email.html.erb
@@ -1,0 +1,8 @@
+<h1>Hi there!</h1>
+<p>
+  <%= @company_name %> has sent you a approval request on Coposition!<br>
+</p>
+<p>
+  To respond, just follow this link: <%= @url %>
+</p>
+<p>Coposition Support</p>

--- a/app/views/user_mailer/add_user_email.html.erb
+++ b/app/views/user_mailer/add_user_email.html.erb
@@ -1,6 +1,6 @@
 <h1>Hi there!</h1>
 <p>
-  <%= @company_name %> has sent you a approval request on Coposition!<br>
+  <%= @from %> has sent you a approval request on Coposition!<br>
 </p>
 <p>
   To respond, just follow this link: <%= @url %>

--- a/app/views/user_mailer/add_user_email.text.erb
+++ b/app/views/user_mailer/add_user_email.text.erb
@@ -1,0 +1,8 @@
+Hi there!
+
+<%= @company %> has sent you a approval request on Coposition!<br>
+
+To respond, just follow this link: <%= @url %>
+
+Coposition Support
+

--- a/app/views/user_mailer/add_user_email.text.erb
+++ b/app/views/user_mailer/add_user_email.text.erb
@@ -1,6 +1,6 @@
 Hi there!
 
-<%= @company %> has sent you a approval request on Coposition!<br>
+<%= @from %> has sent you a approval request on Coposition!<br>
 
 To respond, just follow this link: <%= @url %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
         collection do
           get :auth
         end
-        resources :approvals, only: [:create, :index, :update], module: :users do
+        resources :approvals, only: [:create, :index, :update, :destroy], module: :users do
           collection do
             get :status
           end

--- a/db/migrate/20160602092318_change_user_id_and_add_subscriber_type_to_subscriptions.rb
+++ b/db/migrate/20160602092318_change_user_id_and_add_subscriber_type_to_subscriptions.rb
@@ -1,0 +1,6 @@
+class ChangeUserIdAndAddSubscriberTypeToSubscriptions < ActiveRecord::Migration
+  def change
+    rename_column :subscriptions, :user_id, :subscriber_id
+    add_column :subscriptions, :subscriber_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160520152103) do
+ActiveRecord::Schema.define(version: 20160602092318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,11 +139,12 @@ ActiveRecord::Schema.define(version: 20160520152103) do
   end
 
   create_table "subscriptions", force: :cascade do |t|
-    t.integer  "user_id"
+    t.integer  "subscriber_id"
     t.string   "target_url"
     t.string   "event"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.string   "subscriber_type"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/subscriptions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :controller do
   let(:destroy_params) { params.merge(id: subscription.id) }
 
   before do
-    request.headers['X-Webhook-Key'] = user.webhook_key
+    request.headers['X-Authentication-Key'] = user.webhook_key
   end
 
   describe '#create' do

--- a/spec/controllers/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/subscriptions_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :controller do
   include ControllerMacros
 
   let(:user) { FactoryGirl.create :user }
-  let(:subscription) { FactoryGirl.create :subscription, user: user }
+  let(:subscription) { FactoryGirl.create :subscription, subscriber: user }
   let(:params) { { target_url: "http://#{Faker::Internet.domain_name}/", event: 'new_checkin' } }
   let(:destroy_params) { params.merge(id: subscription.id) }
 

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
   let(:friend_approval_create_params) do
     params.merge(approval: { approvable: second_user.id, approvable_type: 'User' })
   end
-  let(:approval_update_params) do
-    params.merge(id: apprvl.id, approval: { status: 'accepted' })
-  end
+  let(:approval_destroy_params) { params.merge(id: apprvl.id) }
+  let(:approval_update_params) { approval_destroy_params.merge(approval: { status: 'accepted' }) }
 
   before do
     request.headers['X-Api-Key'] = developer.api_key
@@ -112,7 +111,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
       end
     end
 
-    context 'when posting to #update' do
+    context 'making a request to #update' do
       it 'should be able to approve a developer approval request' do
         put :update, approval_update_params
         expect(user.approved?(developer)).to be true
@@ -140,10 +139,11 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
         expect(response.status).to be 404
         expect(user.approved?(developer)).to be false
       end
+    end
 
+    context 'making a request to #destroy' do
       it 'should be able to reject an approval' do
-        approval_update_params[:approval][:status] = 'rejected'
-        put :update, approval_update_params
+        delete :destroy, approval_destroy_params
         expect(Approval.count).to eq 0
         expect(user.approved?(developer)).to be false
       end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     device
   end
   let(:checkin) { FactoryGirl.create :checkin, device: device }
-  let(:subscription) { FactoryGirl.create :subscription, user: user }
+  let(:subscription) { FactoryGirl.create :subscription, subscriber: user }
   let(:create_headers) { request.headers['X-UUID'] = device.uuid }
   let(:address) { 'The Pilot Centre, Denham Aerodrome, Denham Aerodrome, Denham, Buckinghamshire UB9 5DF, UK' }
   let(:params) { { user_id: user.id, device_id: device.id } }

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
   describe '#auth' do
     context 'with a valid webhook key in header' do
       it 'should return status 204 and json message "success"' do
-        request.headers['X-Webhook-Key'] = user.webhook_key
+        request.headers['X-Authentication-Key'] = user.webhook_key
         get :auth
         expect(response.status).to eq 204
         expect(res_hash[:message]).to eq 'Success'

--- a/spec/controllers/developers/approvals_controller_spec.rb
+++ b/spec/controllers/developers/approvals_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Developers::ApprovalsController, type: :controller do
     app.update(approvable: developer, user: user, approvable_type: 'Developer', status: 'accepted')
     app
   end
-  let(:subscription) { FactoryGirl.create :subscription, event: 'create_approval', subscriber: developer }
+  let(:subscription) { FactoryGirl.create :subscription, event: 'new_approval', subscriber: developer }
   let(:developer_params) { { developer_id: developer.id } }
   let(:approval_create_params) do
     developer_params.merge(approval: { user: user.email, approvable_type: 'Developer' })

--- a/spec/controllers/developers/approvals_controller_spec.rb
+++ b/spec/controllers/developers/approvals_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Developers::ApprovalsController, type: :controller do
     app.update(approvable: developer, user: user, approvable_type: 'Developer', status: 'accepted')
     app
   end
+  let(:subscription) { FactoryGirl.create :subscription, event: 'create_approval', subscriber: developer }
   let(:developer_params) { { developer_id: developer.id } }
   let(:approval_create_params) do
     developer_params.merge(approval: { user: user.email, approvable_type: 'Developer' })
@@ -34,6 +35,7 @@ RSpec.describe Developers::ApprovalsController, type: :controller do
 
   describe '#create' do
     it 'should create an approval between user and developer' do
+      subscription
       post :create, approval_create_params
       expect(Approval.last.approvable_id).to eq developer.id
       expect(Approval.last.status).to eq 'developer-requested'

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -22,49 +22,31 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
-  describe 'add_friend_email' do
+  describe 'add_user_email' do
     let(:user) { FactoryGirl.create :user }
-    let(:friend) { FactoryGirl.create :user }
-    let(:mail) { UserMailer.add_friend_email(user, friend) }
+    let(:added_user) { FactoryGirl.create :user }
+    let(:developer) { FactoryGirl.create :developer }
+    let(:friend_mail) { UserMailer.add_user_email(user, added_user, false) }
+    let(:developer_mail) { UserMailer.add_user_email(developer, added_user, true) }
 
     it 'renders the subject' do
-      expect(mail.subject).to match('friend request')
+      expect(friend_mail.subject).to match('approval request')
     end
 
     it 'renders the receiver email' do
-      expect(mail.to).to eql([friend.email])
+      expect(friend_mail.to).to eql([added_user.email])
     end
 
     it 'renders the senders email' do
-      expect(mail.body.encoded).to match(user.email)
+      expect(friend_mail.body.encoded).to match(user.email)
+      expect(developer_mail.body.encoded).to match(developer.company_name)
     end
 
-    it 'renders friends page url' do
-      url_string = "/users/#{friend.id}/friends"
-      expect(mail.body.encoded).to match(url_string)
-    end
-  end
-
-  describe 'add_friend_email' do
-    let(:developer) { FactoryGirl.create :developer }
-    let(:user) { FactoryGirl.create :user }
-    let(:mail) { UserMailer.add_user_email(developer, user) }
-
-    it 'renders the subject' do
-      expect(mail.subject).to match('approval request')
-    end
-
-    it 'renders the receiver email' do
-      expect(mail.to).to eql([user.email])
-    end
-
-    it 'renders the developers company name' do
-      expect(mail.body.encoded).to match(developer.company_name)
-    end
-
-    it 'renders apps page url' do
-      url_string = "/users/#{user.id}/apps"
-      expect(mail.body.encoded).to match(url_string)
+    it 'renders the correct page url' do
+      friends_url_string = "/users/#{added_user.id}/friends"
+      apps_url_string = "/users/#{added_user.id}/apps"
+      expect(friend_mail.body.encoded).to match(friends_url_string)
+      expect(developer_mail.body.encoded).to match(apps_url_string)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.body.encoded).to match(url_string)
     end
   end
+
+  describe 'add_friend_email' do
+    let(:developer) { FactoryGirl.create :developer }
+    let(:user) { FactoryGirl.create :user }
+    let(:mail) { UserMailer.add_user_email(developer, user) }
+
+    it 'renders the subject' do
+      expect(mail.subject).to match('approval request')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eql([user.email])
+    end
+
+    it 'renders the developers company name' do
+      expect(mail.body.encoded).to match(developer.company_name)
+    end
+
+    it 'renders apps page url' do
+      url_string = "/users/#{user.id}/apps"
+      expect(mail.body.encoded).to match(url_string)
+    end
+  end
 end


### PR DESCRIPTION
Made subscriptions polymorphic so they can belong to either a User or a Developer (subscriber).

Added method to notify Developer's who have a subscription for a new approval being created/approved/attempted to be created by either a user or a developer in either the API or the web app.

Made add_friend_email work for developers trying to add a user as well, not actually being used though but option is there.

Added destroy approval action to API approvals_controller instead of using update as more conventional.