### PR TITLE
Zapier data

### DIFF
--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     Approval.link(@user, approvable, approvable_type)
     accept_if_friend_request_or_adding_developer if req_from_coposition_app?
     approval = @user.approval_for(approvable)
-    @dev.notify_if_subscribed('new_approval', [@user.public_info, approval])
+    @dev.notify_if_subscribed('new_approval', zapier_data(@user, approval))
     render json: approval
   end
 
@@ -21,7 +21,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     type = approval.approvable_type
     Approval.accept(@user, approvable, type)
     render json: approval.reload
-    approvable.notify_if_subscribed('new_approval', [@user.public_info, approval]) if type == 'Developer'
+    approvable.notify_if_subscribed('new_approval', zapier_data(@user, approval)) if type == 'Developer'
   end
 
   def destroy
@@ -65,5 +65,9 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     if @user.request_from?(approvable) || approvable_type == 'Developer'
       Approval.accept(@user, approvable, approvable_type)
     end
+  end
+
+  def zapier_data(user, approval)
+    [user.public_info.as_json.merge(approval.as_json)]
   end
 end

--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     Approval.link(@user, approvable, approvable_type)
     accept_if_friend_request_or_adding_developer if req_from_coposition_app?
     approval = @user.approval_for(approvable)
-    @dev.notify_if_subscribed('new_approval', zapier_data(@user, approval))
+    @dev.notify_if_subscribed('new_approval', approval_zapier_data(approval))
     render json: approval
   end
 
@@ -21,7 +21,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     type = approval.approvable_type
     Approval.accept(@user, approvable, type)
     render json: approval.reload
-    approvable.notify_if_subscribed('new_approval', zapier_data(@user, approval)) if type == 'Developer'
+    approvable.notify_if_subscribed('new_approval', approval_zapier_data(approval)) if type == 'Developer'
   end
 
   def destroy
@@ -65,9 +65,5 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
     if @user.request_from?(approvable) || approvable_type == 'Developer'
       Approval.accept(@user, approvable, approvable_type)
     end
-  end
-
-  def zapier_data(user, approval)
-    [user.public_info.as_json.merge(approval.as_json)]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,6 @@ class ApplicationController < ActionController::Base
   end
 
   def approval_zapier_data(approval)
-    [current_user.public_info, approval]
+    [current_user.public_info.as_json.merge(approval.as_json)]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,4 @@ class ApplicationController < ActionController::Base
     @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
     gon.push(@presenter.gon)
   end
-
-  def approval_zapier_data(approval)
-    [current_user.public_info.as_json.merge(approval.as_json)]
-  end
 end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -26,8 +26,8 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def zapier_data(email, user)
-    zapier_data = [email: email]
-    return zapier_data unless user
-    zapier_data.push(user.public_info, user.approval_for(current_developer))
+    zapier_data = { email: email }
+    return [zapier_data] unless user
+    [zapier_data.merge(user.public_info.as_json).merge(user.approval_for(current_developer).as_json)]
   end
 end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -26,7 +26,7 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def zapier_data(email, user)
-    return [{ email: email }] unless user
+    return [{ email: email, message: 'User not registered with Coposition' }] unless user
     approval = user.approval_for(current_developer)
     approval_zapier_data(approval)
   end

--- a/app/controllers/developers/approvals_controller.rb
+++ b/app/controllers/developers/approvals_controller.rb
@@ -26,8 +26,8 @@ class Developers::ApprovalsController < ApplicationController
   end
 
   def zapier_data(email, user)
-    zapier_data = { email: email }
-    return [zapier_data] unless user
-    [zapier_data.merge(user.public_info.as_json).merge(user.approval_for(current_developer).as_json)]
+    return [{ email: email }] unless user
+    approval = user.approval_for(current_developer)
+    approval_zapier_data(approval)
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -101,12 +101,12 @@ class Device < ActiveRecord::Base
   end
 
   def notify_subscribers(event, data)
-    zapier_data = [data]
-    zapier_data << public_info unless data.model_name == 'Device'
-    zapier_data << user.public_info if user
+    data = data.as_json
+    data.merge!(public_info.as_json) unless data[:model_name] == 'Device'
+    data.merge!(user.public_info.as_json) if user
     subscriptions(event).each do |subscription|
-      subscription.send_data(zapier_data)
-    end unless subscriptions(event).empty?
+      subscription.send_data([data])
+    end
   end
 
   def self.public_info

--- a/lib/api_application_mixin.rb
+++ b/lib/api_application_mixin.rb
@@ -24,4 +24,8 @@ module ApiApplicationMixin
   def req_from_coposition_app?
     request.headers['X-Secret-App-Key'] == Rails.application.secrets.mobile_app_key
   end
+
+  def approval_zapier_data(approval)
+    [approval.user.public_info.as_json.merge(approval.as_json)]
+  end
 end


### PR DESCRIPTION
Changed the data sent to Zapier to be an array with one hash containing all relevant data instead of an array of hashes as this is what it expects.