### PR TITLE
Device config

### DIFF
--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::CheckinsController < Api::ApiController
     checkin = @device.checkins.create(allowed_params)
     if checkin.save
       @device.notify_subscribers('new_checkin', checkin)
-      render json: [checkin]
+      render json: [checkin, @device.config]
     else
       render status: 400, json: { message: 'You must provide a lat and lng' }
     end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -42,7 +42,8 @@ class Api::V1::CheckinsController < Api::ApiController
     checkin = @device.checkins.create(allowed_params)
     if checkin.save
       @device.notify_subscribers('new_checkin', checkin)
-      render json: [checkin, @device.config]
+      config = @dev.configs.find_by(id: @device.id)
+      render json: [checkin, config]
     else
       render status: 400, json: { message: 'You must provide a lat and lng' }
     end

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -8,13 +8,12 @@ class Api::V1::ConfigsController < Api::ApiController
   end
 
   def show
-    config = @dev.configs.find_by(device_id: params[:id])
+    config = @dev.configs.find(params[:id])
     render json: config
   end
 
   def update
-    config = @dev.configs.find_by(device_id: params[:id])
-    return unless config_exists? config
+    config = @dev.configs.find(params[:id])
     config.update(custom: custom_params)
     render json: config
   end

--- a/spec/controllers/api/v1/configs_controller_spec.rb
+++ b/spec/controllers/api/v1/configs_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::ConfigsController, type: :controller do
 
     it 'should return a message if config does not exist' do
       put :update, update_params.merge(id: 0)
-      expect(res_hash[:message]).to match 'Config does not exist'
+      expect(res_hash[:error]).to match "Couldn't find Config"
     end
   end
 end


### PR DESCRIPTION
Changed config routes to use config ID rather than device id as most restful. Added config to checkin post response if developer controls device.