### PR TITLE
api-standards

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,6 +1,7 @@
 class Api::ApiController < ActionController::Base
   include ApiApplicationMixin
-  rescue_from ::ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ::ActiveRecord::RecordNotFound, with: :render_404_and_error
+  rescue_from ::ActionController::ParameterMissing, with: :render_404_and_error
 
   before_action :find_user, :authenticate
 
@@ -20,7 +21,7 @@ class Api::ApiController < ActionController::Base
     if @dev
       create_request
     else
-      render status: 401, json: { message: 'No valid API Key' }
+      render status: 401, json: { error: 'No valid API Key' }
     end
   end
 
@@ -36,9 +37,9 @@ class Api::ApiController < ActionController::Base
     @permissible = find_permissible
     return if req_from_coposition_app?
     if !@user.approved?(@dev)
-      render status: 401, json: { "approval status": @user.approval_for(@dev).status }
+      render status: 401, json: { error: "Approval_status: #{@user.approval_for(@dev).status}" }
     elsif !@user.approved?(@permissible)
-      render status: 401, json: { "approval status": @user.approval_for(@permissible).status }
+      render status: 401, json: { error: "Approval_status: #{@user.approval_for(@permissible).status}" }
     end
   end
 
@@ -60,11 +61,11 @@ class Api::ApiController < ActionController::Base
 
   def resource_exists?(resource, arguments)
     model = resource.titleize.constantize
-    render status: 404, json: { message: "#{model} does not exist" } unless arguments
+    render status: 404, json: { error: "#{model} does not exist" } unless arguments
     arguments
   end
 
-  def record_not_found(exception)
-    render json: { error: exception.message }.to_json, status: 404
+  def render_404_and_error(exception)
+    render status: 404, json: { error: exception.message }
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -37,9 +37,9 @@ class Api::ApiController < ActionController::Base
     @permissible = find_permissible
     return if req_from_coposition_app?
     if !@user.approved?(@dev)
-      render status: 401, json: { error: "Approval_status: #{@user.approval_for(@dev).status}" }
+      render status: 401, json: { error: "approval_status: #{@user.approval_for(@dev).status}" }
     elsif !@user.approved?(@permissible)
-      render status: 401, json: { error: "Approval_status: #{@user.approval_for(@permissible).status}" }
+      render status: 401, json: { error: "approval_status: #{@user.approval_for(@permissible).status}" }
     end
   end
 

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::CheckinsController < Api::ApiController
       config = @dev.configs.find_by(device_id: @device.id)
       render json: { data: [checkin], config: config }
     else
-      render status: 400, json: { message: 'You must provide a lat and lng' }
+      render status: 400, json: { error: 'You must provide a lat and lng' }
     end
   end
 
@@ -53,7 +53,7 @@ class Api::V1::CheckinsController < Api::ApiController
 
   def device_exists?
     if (@device = Device.find_by(uuid: request.headers['X-UUID'])).nil?
-      render status: 400, json: { message: 'You must provide a valid uuid' }
+      render status: 400, json: { error: 'You must provide a valid uuid' }
     end
   end
 

--- a/app/controllers/api/v1/users/approvals_controller.rb
+++ b/app/controllers/api/v1/users/approvals_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::Users::ApprovalsController < Api::ApiController
   end
 
   def check_user
-    render status: 403, json: { message: 'Incorrect User' } unless current_user?(params[:user_id])
+    render status: 403, json: { error: 'Incorrect User' } unless current_user?(params[:user_id])
   end
 
   def approvable_type

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
       device = result.device
       render json: device
     else
-      render status: 400, json: { message: result.error }
+      render status: 400, json: { error: result.error }
     end
   end
 
@@ -37,7 +37,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
   private
 
   def check_user
-    render status: 403, json: { message: 'User does not own device' } unless current_user?(params[:user_id])
+    render status: 403, json: { error: 'User does not own device' } unless current_user?(params[:user_id])
   end
 
   def device_params

--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -30,10 +30,10 @@ class Api::V1::Users::PermissionsController < Api::ApiController
 
   def require_ownership
     if params[:id]
-      render status: 403, json: { message: 'You do not control that permission' } unless user_owns_permission?
+      render status: 403, json: { error: 'You do not control that permission' } unless user_owns_permission?
     else
       params[:id] = params[:device_id]
-      render status: 403, json: { message: 'You do not control that device' } unless user_owns_device?
+      render status: 403, json: { error: 'You do not control that device' } unless user_owns_device?
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::UsersController < Api::ApiController
     if subscriber
       render status: 204, json: { message: 'Success' }
     else
-      render status: 400, json: { message: 'Invalid webhook key supplied' }
+      render status: 400, json: { error: 'Invalid webhook key supplied' }
     end
   end
 end

--- a/app/controllers/users/devise/sessions_controller.rb
+++ b/app/controllers/users/devise/sessions_controller.rb
@@ -31,7 +31,7 @@ class Users::Devise::SessionsController < Devise::SessionsController
     user = User.find_by(authentication_token: request.headers['X-User-Token'])
 
     if user.nil?
-      render status: 404, json: { message: 'Invalid token.' }
+      render status: 404, json: { error: 'Invalid token.' }
     else
       user.authentication_token = nil
       user.save!
@@ -43,7 +43,7 @@ class Users::Devise::SessionsController < Devise::SessionsController
     if (@user = User.find_by(email: email)) && @user.valid_password?(password)
       @user
     else
-      render status: 401, json: { message: 'The request MUST contain the user email and password.' }
+      render status: 401, json: { error: 'The request MUST contain the user email and password.' }
       return false
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
         resources :sessions, only: [:create, :destroy]
       end
     end
+    match '*path', to: -> (_env) { [404, {}, ['{"error": "route_not_found"}']] }, via: :all
   end
 
   # Users

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
 
       it 'should not be able to approve if not signed in user' do
         put :update, approval_update_params.merge(user_id: second_user.id)
-        expect(res_hash[:message]).to match('Incorrect User')
+        expect(res_hash[:error]).to match('Incorrect User')
         expect(response.status).to be 403
         expect(user.approved?(developer)).to be false
       end
@@ -135,7 +135,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
       it 'should not be able to approve an approval that does not belong to you' do
         second_user.approvals.create(approvable_id: developer.id)
         put :update, approval_update_params.merge(id: second_user.approvals.last.id)
-        expect(res_hash[:message]).to match('does not exist')
+        expect(res_hash[:error]).to match('does not exist')
         expect(response.status).to be 404
         expect(user.approved?(developer)).to be false
       end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     context 'without developer approval' do
       it "shouldn't fetch the last reported location", :skip_before do
         get :last, params
-        expect(res_hash[:approval_status]).to be nil
+        expect(res_hash[:error]).to eq 'Approval_status: No Approval'
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         Approval.link(user, developer, 'Developer')
         Approval.accept(user, developer, 'Developer')
         get :last, params.merge(permissible_id: second_user.id)
-        expect(res_hash[:approval_status]).to be nil
+        expect(res_hash[:error]).to eq 'Approval_status: No Approval'
       end
     end
 
@@ -200,14 +200,14 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       create_headers
       post :create, checkin: { lat: Faker::Address.latitude }
       expect(response.status).to eq(400)
-      expect(res_hash[:message]).to eq('You must provide a lat and lng')
+      expect(res_hash[:error]).to eq('You must provide a lat and lng')
     end
 
     it 'should return 400 if you POST a checkin with invalid uuid' do
       request.headers['X-UUID'] = 'thisdevicedoesntexist'
       post :create, create_params
       expect(response.status).to eq(400)
-      expect(res_hash[:message]).to eq('You must provide a valid uuid')
+      expect(res_hash[:error]).to eq('You must provide a valid uuid')
     end
   end
 end

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     context 'without developer approval' do
       it "shouldn't fetch the last reported location", :skip_before do
         get :last, params
-        expect(res_hash[:error]).to eq 'Approval_status: No Approval'
+        expect(res_hash[:error]).to eq 'approval_status: No Approval'
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         Approval.link(user, developer, 'Developer')
         Approval.accept(user, developer, 'Developer')
         get :last, params.merge(permissible_id: second_user.id)
-        expect(res_hash[:error]).to eq 'Approval_status: No Approval'
+        expect(res_hash[:error]).to eq 'approval_status: No Approval'
       end
     end
 

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
       count = user.devices.count
       post :create, create_params
       expect(user.devices.count).to be count
-      expect(res_hash[:message]).to match 'registered to another user'
+      expect(res_hash[:error]).to match 'registered to another user'
     end
 
     it 'should fail to to create a device with a taken name' do
       create_params[:device] = { name: device.name }
       post :create, create_params
-      expect(res_hash[:message]).to match device.name
+      expect(res_hash[:error]).to match device.name
     end
   end
 
@@ -95,13 +95,13 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
     it 'should reject non-existant device ids' do
       put :update, device_params.merge(id: 9999999, device: { fogged: true })
       expect(response.status).to eq(404)
-      expect(res_hash[:message]).to eq('Device does not exist')
+      expect(res_hash[:error]).to eq('Device does not exist')
     end
 
     it 'should not allow you to update someone elses device' do
       put :update, user_id: second_user.id, id: second_user.devices.last.id, device: { fogged: true }, format: :json
       expect(response.status).to eq(403)
-      expect(res_hash[:message]).to eq('User does not own device')
+      expect(res_hash[:error]).to eq('User does not own device')
     end
   end
 end

--- a/spec/controllers/api/v1/users/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/users/permissions_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
           device_id: second_device.id,
           id: permission.id
       expect(response.status).to be 403
-      expect(res_hash[:message]).to eq 'You do not control that permission'
+      expect(res_hash[:error]).to eq 'You do not control that permission'
     end
   end
 
@@ -79,7 +79,7 @@ RSpec.describe Api::V1::Users::PermissionsController, type: :controller do
       put :update_all,
           device_id: second_device.id,
           user_id: user.id
-      expect(res_hash[:message]).to eq 'You do not control that device'
+      expect(res_hash[:error]).to eq 'You do not control that device'
     end
   end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'should render status 401 with message' do
         get :show, id: user.id, format: :json
         expect(response.status).to eq 401
-        expect(res_hash[:message]).to eq 'No valid API Key'
+        expect(res_hash[:error]).to eq 'No valid API Key'
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'should return status 400 and json message "Invalid webhook key supplied"' do
         get :auth
         expect(response.status).to eq 400
-        expect(res_hash[:message]).to eq 'Invalid webhook key supplied'
+        expect(res_hash[:error]).to eq 'Invalid webhook key supplied'
       end
     end
   end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Users::Devise::SessionsController, type: :controller do
         request.headers['X-User-Token'] = 'invalid token'
         request.env['devise.mapping'] = Devise.mappings[:user]
         post :destroy, params
-        expect(res_hash[:message]).to eq 'Invalid token.'
+        expect(res_hash[:error]).to eq 'Invalid token.'
         post :create, params.delete('password')
-        expect(res_hash[:message]).to eq 'The request MUST contain the user email and password.'
+        expect(res_hash[:error]).to eq 'The request MUST contain the user email and password.'
       end
     end
   end


### PR DESCRIPTION
Made api return { error: some_error } everywhere instead of { message: some_error } in some places, fixed tests, also catching param errors.

Catching routing errors in routes file, renders 404 and route_not_found error instead of unhelpful exception.