### PR TITLE
Approve mobile app

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,6 +35,9 @@
     "COPOSITION_API_KEY":{
       "required":true
     },
+    "MOBILE_APP_API_KEY":{
+      "required":true
+    },
     "GOOGLE_MAPS_API_KEY":{
       "required":true
     }

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -34,7 +34,7 @@ class Users::DevicesController < ApplicationController
   end
 
   def create
-    result = Users::Devices::CreateDevice.new(current_user, default_developer, allowed_params)
+    result = Users::Devices::CreateDevice.new(current_user, Developer.coposition, allowed_params)
     if result.save?
       device = result.device
       gon.checkins = create_checkin(device)
@@ -85,10 +85,5 @@ class Users::DevicesController < ApplicationController
 
   def published?
     redirect_to root_path, notice: 'Device is not shared' unless Device.find(params[:id]).published?
-  end
-
-  def default_developer
-    return FactoryGirl.create(:developer) if Rails.env.test?
-    Developer.find_by(api_key: Rails.application.secrets.coposition_api_key)
   end
 end

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -34,7 +34,7 @@ class Users::DevicesController < ApplicationController
   end
 
   def create
-    result = Users::Devices::CreateDevice.new(current_user, Developer.coposition, allowed_params)
+    result = Users::Devices::CreateDevice.new(current_user, Developer.default(coposition: true), allowed_params)
     if result.save?
       device = result.device
       gon.checkins = create_checkin(device)

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,6 +1,5 @@
 class Developer < ActiveRecord::Base
-  include ApprovalMethods
-  include SlackNotifiable
+  include ApprovalMethods, SlackNotifiable
 
   has_attachment :avatar
 
@@ -44,5 +43,15 @@ class Developer < ActiveRecord::Base
 
   def configures_device?(device)
     configs.where(device: device).present?
+  end
+
+  def self.coposition
+    return FactoryGirl.create(:developer) if Rails.env.test?
+    find_by(api_key: Rails.application.secrets.coposition_api_key)
+  end
+
+  def self.mobile_app
+    return FactoryGirl.create(:developer) if Rails.env.test?
+    find_by(api_key: Rails.application.secrets.mobile_app_api_key)
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -47,7 +47,7 @@ class Developer < ActiveRecord::Base
 
   def self.default(type)
     return FactoryGirl.create(:developer) if Rails.env.test?
-    key = type.coposition ? Rails.application.secrets.coposition_api_key : Rails.application.secrets.mobile_app_api_key
-    find_by(api_key: key)
+    key = type[:coposition] ? 'coposition_api_key' : 'mobile_app_api_key'
+    find_by(api_key: Rails.application.secrets[key])
   end
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -45,13 +45,9 @@ class Developer < ActiveRecord::Base
     configs.where(device: device).present?
   end
 
-  def self.coposition
+  def self.default(type)
     return FactoryGirl.create(:developer) if Rails.env.test?
-    find_by(api_key: Rails.application.secrets.coposition_api_key)
-  end
-
-  def self.mobile_app
-    return FactoryGirl.create(:developer) if Rails.env.test?
-    find_by(api_key: Rails.application.secrets.mobile_app_api_key)
+    key = type.coposition ? Rails.application.secrets.coposition_api_key : Rails.application.secrets.mobile_app_api_key
+    find_by(api_key: key)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
   ## Approvals
 
   def approve_coposition_mobile_app
-    Approval.add_developer(self, Developer.default(mobile_app: true))
+    Approval.add_developer(self, Developer.default(mobile: true))
   end
 
   def approved?(permissible)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ActiveRecord::Base
 
   before_create :generate_token, unless: :webhook_key?
 
-  after_create :approve_coposition
+  after_create :approve_coposition_mobile_app
 
   has_attachment :avatar
   ## Pathing
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
 
   ## Approvals
 
-  def approve_coposition
+  def approve_coposition_mobile_app
     Approval.add_developer(self, Developer.default(mobile_app: true))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ActiveRecord::Base
   ## Approvals
 
   def approve_coposition
-    Approval.add_developer(self, Developer.mobile_app)
+    Approval.add_developer(self, Developer.default(mobile_app: true))
   end
 
   def approved?(permissible)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 class User < ActiveRecord::Base
   extend FriendlyId
-  include ApprovalMethods
-  include SlackNotifiable
+  include ApprovalMethods, SlackNotifiable
 
   acts_as_token_authenticatable
 
@@ -40,6 +39,8 @@ class User < ActiveRecord::Base
 
   before_create :generate_token, unless: :webhook_key?
 
+  after_create :approve_coposition
+
   has_attachment :avatar
   ## Pathing
 
@@ -48,6 +49,10 @@ class User < ActiveRecord::Base
   end
 
   ## Approvals
+
+  def approve_coposition
+    Approval.add_developer(self, Developer.mobile_app)
+  end
 
   def approved?(permissible)
     developers.include?(permissible) || friends.include?(permissible)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,11 @@ class User < ActiveRecord::Base
 
   friendly_id :username, use: [:slugged, :finders]
 
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable,
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable,
          authentication_keys: { username: false, email: true }
 
-  validates :username, uniqueness: true,
-                       allow_blank: true,
-                       format: { with: /\A[-a-zA-Z_]+\z/,
-                                 message: 'only allows letters, underscores and dashes' }
+  validates :username, uniqueness: true, allow_blank: true,
+                       format: { with: /\A[-a-zA-Z_]+\z/, message: 'only allows letters, underscores and dashes' }
 
   has_many :devices, dependent: :destroy
   has_many :checkins, through: :devices

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,7 @@ development:
   secret_key_base: 5009b4a407c9350f1ce99efa44c8f53866e5e37f14540295260bed09363b464e5d570d74eaaafa99f78c9b438849902d5d32448267fb5698e49101c71c8e8791
   mobile_app_key: "this-is-a-mobile-app"
   coposition_api_key: "this-is-a-coposition-api-key"
+  mobile_app_api_key: "this-is-a-mobile-app-api-key"
 
 test:
   secret_key_base: 2c895373f134e0f9c184b80c2e9a8e796bca2be9e9b0bd306b08d30adada497f328202760f0e3520387e525f2a76a596e033a92f8da73d45b6ea9ac6ec7bd136
@@ -26,4 +27,5 @@ production:
   mobile_app_key: <%= ENV["MOBILE_APP_KEY"] %>
   webhook_url: <%= ENV["SLACK_WEBHOOK_URL"] %>
   coposition_api_key: <%= ENV["COPOSITION_API_KEY"] %>
+  mobile_app_api_key: <%= ENV["MOBILE_APP_API_KEY"] %>
 

--- a/features/approvals.feature
+++ b/features/approvals.feature
@@ -16,6 +16,7 @@ Feature: Approvals
 
     Scenario: User rejects requests
       When I click "Reject"
+        And I click "Revoke Approval"
         Then I should not have any approved apps
       And I click the link "Friends"
       When I click "Reject"

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
     context 'when post to create' do
       it 'should be able to create a developer approval' do
         post :create, dev_approval_create_params
-        expect(Approval.where(user: user, approvable: developer, status: 'accepted')).to exist
+        expect(Approval.where(approvable: developer, status: 'accepted', user: user)).to exist
       end
 
       it 'should be able to create a user approval request' do

--- a/spec/controllers/api/v1/users/approvals_controller_spec.rb
+++ b/spec/controllers/api/v1/users/approvals_controller_spec.rb
@@ -25,23 +25,26 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
   describe 'a developer' do
     it 'should be able to submit an approval request' do
       post :create, dev_approval_create_params
-      expect(Approval.first.status).to eq 'developer-requested'
+      expect(Approval.where(user: user, approvable: developer, status: 'developer-requested')).to exist
       expect(user.pending_approvals.count).to be 1
     end
 
     it 'should be not be able to submit another request to same user' do
+      dev_approval_create_params
       Approval.link(user, developer, 'Developer')
+      approval_count = Approval.count
       post :create, dev_approval_create_params
-      expect(Approval.count).to eq 1
-      expect(Approval.first.status).to eq 'developer-requested'
+      expect(Approval.count).to eq approval_count
       expect(user.pending_approvals.count).to be 1
     end
 
     it 'should be not be able to submit an approval request for another user' do
+      friend_approval_create_params
       Approval.link(user, developer, 'Developer')
+      approval_count = Approval.count
       post :create, friend_approval_create_params
-      expect(Approval.count).to_not be 2
-      expect(Approval.first.approvable).to_not be second_user
+      expect(Approval.count).to be approval_count
+      expect(Approval.where(approvable: second_user)).to_not exist
     end
 
     it 'should be told if the approval is still pending' do
@@ -72,33 +75,31 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
     context 'when post to create' do
       it 'should be able to create a developer approval' do
         post :create, dev_approval_create_params
-        expect(Approval.last.user).to eq user
-        expect(Approval.last.approvable_id).to eq developer.id
-        expect(Approval.last.status).to eq 'accepted'
+        expect(Approval.where(user: user, approvable: developer, status: 'accepted')).to exist
       end
 
       it 'should be able to create a user approval request' do
+        friend_approval_create_params
+        approval_count = Approval.count
         post :create, friend_approval_create_params
-        expect(Approval.count).to eq 2
-        expect(Approval.last.user).to eq second_user
-        expect(Approval.last.approvable_id).to eq user.id
-        expect(Approval.last.status).to eq 'requested'
+        expect(Approval.count).to eq approval_count + 2
+        expect(Approval.where(user: second_user, approvable: user, status: 'requested')).to exist
       end
 
       it 'should be not be able to submit another request to same user' do
         Approval.link(user, second_user, 'User')
+        approval_count = Approval.count
         post :create, friend_approval_create_params
-        expect(Approval.count).to eq 2
-        expect(Approval.first.status).to eq 'pending'
-        expect(Approval.last.status).to eq 'requested'
+        expect(Approval.count).to eq approval_count
+        expect(Approval.where(approvable_type: 'User', status: 'accepted')).to_not exist
       end
 
       it 'should approve a developer request' do
         request.headers['X-Secret-App-Key'] = 'this-is-a-mobile-app'
         Approval.link(user, developer, 'Developer')
-        expect(Approval.last.status).to eq 'developer-requested'
+        expect(Approval.where(user: user, approvable: developer, status: 'developer-requested')).to exist
         post :create, dev_approval_create_params
-        expect(Approval.last.status).to eq 'accepted'
+        expect(Approval.where(user: user, approvable: developer, status: 'accepted')).to exist
       end
 
       it 'should approve a friend request' do
@@ -120,7 +121,7 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
       it 'should be able to approve a user approval request' do
         Approval.link(user, second_user, 'User')
         expect(user.friends.include?(second_user)).to be false
-        put :update, approval_update_params.merge(id: Approval.first)
+        put :update, approval_update_params.merge(id: Approval.find_by(user: user, approvable_type: 'User').id)
         expect(second_user.friends.include?(user)).to be true
         expect(user.friends.include?(second_user)).to be true
       end
@@ -143,8 +144,10 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
 
     context 'making a request to #destroy' do
       it 'should be able to reject an approval' do
+        approval_destroy_params
+        approval_count = Approval.count
         delete :destroy, approval_destroy_params
-        expect(Approval.count).to eq 0
+        expect(Approval.count).to eq approval_count - 1
         expect(user.approved?(developer)).to be false
       end
     end
@@ -159,13 +162,13 @@ RSpec.describe Api::V1::Users::ApprovalsController, type: :controller do
 
     it 'should get a list of a users approvals' do
       get :index, params
-      expect(res_hash.length).to eq 2
+      expect(res_hash.length).to eq Approval.where(user: user).count
       expect(res_hash.first['user_id']).to eq user.id
     end
 
     it 'should get a list of a users accepted friend approvals' do
       get :index, params.merge(type: 'friends')
-      expect(res_hash.length).to eq 1
+      expect(res_hash.length).to eq Approval.where(user: user, approvable_type: 'User').count
       expect(res_hash.first['status']).to eq 'accepted'
       expect(res_hash.first['approvable_type']).to eq 'User'
     end

--- a/spec/controllers/developers/approvals_controller_spec.rb
+++ b/spec/controllers/developers/approvals_controller_spec.rb
@@ -40,32 +40,34 @@ RSpec.describe Developers::ApprovalsController, type: :controller do
     it 'should create an approval between user and developer' do
       subscription
       post :create, approval_create_params
-      expect(Approval.last.approvable_id).to eq developer.id
-      expect(Approval.last.status).to eq 'developer-requested'
-      expect(Approval.last.user).to eq user
+      expect(Approval.where(user: user, approvable: developer, status: 'developer-requested')).to exist
       expect(flash[:notice]).to match 'Successfully sent'
     end
 
     it 'should fail to create an approval if request exists' do
       approval
+      approval_count = Approval.count
       post :create, approval_create_params
       expect(flash[:alert]).to match 'Approval already exists'
-      expect(Approval.count).to eq 1
+      expect(Approval.count).to eq approval_count
     end
 
     it 'should fail to create an approval if user does not exist' do
       approval_create_params[:approval][:user] = 'does not exist'
+      approval_count = Approval.count
       post :create, approval_create_params
       expect(flash[:alert]).to match 'User does not exist'
-      expect(Approval.count).to eq 0
+      expect(Approval.count).to eq approval_count
     end
   end
 
   describe '#destroy' do
     it 'should destroy an approval between user and developer' do
+      approval
+      approval_count = Approval.count
       request.accept = 'text/javascript'
       delete :destroy, approval_destroy_params
-      expect(Approval.count).to eq 0
+      expect(Approval.count).to eq approval_count - 1
       expect(user.approval_for(developer).class).to eq NoApproval
     end
   end

--- a/spec/controllers/users/create_dev_approvals_controller_spec.rb
+++ b/spec/controllers/users/create_dev_approvals_controller_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe Users::CreateDevApprovalsController, type: :controller do
     context 'when adding a developer' do
       it 'should create an accepted approval between user and developer' do
         post :create, approval_create_params
-        expect(Approval.last.approvable_id).to eq developer.id
-        expect(Approval.last.status).to eq 'accepted'
-        expect(Approval.last.user).to eq user
+        expect(Approval.where(user: user, approvable: developer, status: 'accepted')).to exist
       end
 
       it 'should confirm an existing developer approval request' do
@@ -23,22 +21,23 @@ RSpec.describe Users::CreateDevApprovalsController, type: :controller do
         count = Approval.count
         post :create, approval_create_params
         expect(Approval.count).to eq count
-        expect(Approval.last).to eq approval
-        expect(Approval.last.status).to eq 'accepted'
+        expect(Approval.where(user: user, approvable: developer, status: 'accepted')).to exist
       end
 
       it 'should not create an approval if Developer does not exist' do
         approval_create_params[:approval][:approvable] = 'does not exist'
+        approval_count = Approval.count
         post :create, approval_create_params
-        expect(Approval.count).to eq 0
+        expect(Approval.count).to eq approval_count
         expect(flash[:alert]).to match 'not found'
       end
 
       it 'should not approve if trying to add an already approved developer' do
         approval.update(status: 'accepted', approvable_id: developer.id, approvable_type: 'Developer')
+        approval_count = Approval.count
         post :create, approval_create_params
         expect(flash[:alert]).to match 'exists'
-        expect(Approval.count).to eq 1
+        expect(Approval.count).to eq approval_count
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe User, type: :model do
 
   describe 'approvals' do
     it 'should approve a developer' do
+      developer_count = user.developers.count
       expect(user.pending_approvals.count).to be 0
       expect(user.approved?(developer)).to be false
 
@@ -43,11 +44,11 @@ RSpec.describe User, type: :model do
       user.save
 
       expect(user.pending_approvals.count).to be 1
-      expect(user.developers.count).to be 0
+      expect(user.developers.count).to be developer_count
 
       Approval.accept(user, developer, 'Developer')
       expect(user.pending_approvals.count).to be 0
-      expect(user.developers.count).to be 1
+      expect(user.developers.count).to be developer_count + 1
     end
 
     it 'should approve devices for a developer by default when a developer is approved' do


### PR DESCRIPTION
Added an after_create on the User model which approves the coposition mobile app. 

NOTE: You will need to create a new developer with the api_key: 'this-is-a-mobile-app-api-key' on your development environment.

Also added a method to the Developer model which returns either the default coposition developer account or the coposition mobile app developer account.

Reduced length of User model (codeclimate). 

Tests.