### PR TITLE
zapier-data

### DIFF
--- a/app/models/concerns/remove_id.rb
+++ b/app/models/concerns/remove_id.rb
@@ -1,0 +1,8 @@
+require 'active_support/concern'
+
+module RemoveId
+  extend ActiveSupport::Concern
+  def remove_id
+    attributes.delete_if { |key, _value| key == 'id' }
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,7 +1,5 @@
 class Device < ActiveRecord::Base
-  include SlackNotifiable
-  include SwitchFogging
-  include HumanizeMinutes
+  include SlackNotifiable, SwitchFogging, HumanizeMinutes, RemoveId
 
   belongs_to :user
   has_one :config
@@ -99,8 +97,8 @@ class Device < ActiveRecord::Base
 
   def notify_subscribers(event, data)
     data = data.as_json
-    data.merge!(public_info.as_json) unless data[:model_name] == 'Device'
-    data.merge!(user.public_info.as_json) if user
+    data.merge!(remove_id.as_json)
+    data.merge!(user.public_info.remove_id.as_json) if user
     subscriptions(event).each { |subscription| subscription.send_data([data]) }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   extend FriendlyId
-  include ApprovalMethods, SlackNotifiable
+  include ApprovalMethods, SlackNotifiable, RemoveId
 
   acts_as_token_authenticatable
 


### PR DESCRIPTION
User was only receiving public device info, changed so providing full info. Removing ID of data's device/user so that id represents the ID of the data, as device_id and user_id is present we don't need their id's.