### PR TITLE
device-show-fix

### DIFF
--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -23,6 +23,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
 
   def show
     device = @user.devices.where(id: params[:id]).first
+    return unless device_exists? device
     device = device.public_info unless req_from_coposition_app? || @dev.configures_device?(device)
     render json: { data: device, config: configuration(device) }
   end

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
       expect(res_hash[:config]['id']).to eq developer.configs.find_by(device: device).id
       expect(res_hash[:data].keys).to include(*private_device_info)
     end
+
+    it 'should return an error message if device does not exist' do
+      get :show, params: device_params.merge(id: 9999999)
+      expect(res_hash[:error]).to eq('Device does not exist')
+      expect(response.status).to eq 404
+    end
   end
 
   describe 'POST' do


### PR DESCRIPTION
API devices #show now returns 404 + error message if device id supplied does not match a device belonging to the user.