### PR TITLE
Zapier friend

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -97,13 +97,9 @@ class Device < ApplicationRecord
 
   def notify_friends(data)
     Subscription.where(event: 'friend_new_checkin').where(subscriber_id: user.friends).each do |sub|
-      checkin = safe_checkin_info_for(
-        permissible: sub.subscriber,
-        type: 'address',
-        action: 'last'
-      )
-      next unless checkin[0] && checkin[0]['id'] == data['id']
-      sub.send_data(checkin)
+      checkin = safe_checkin_info_for(permissible: sub.subscriber, type: 'address', action: 'last')[0]
+      next unless checkin && checkin['id'] == data['id']
+      sub.send_data([checkin])
     end
   end
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -74,7 +74,7 @@ class Device < ApplicationRecord
   end
 
   def update_delay(mins)
-    mins.to_i == 0 ? update(delayed: nil) : update(delayed: mins)
+    mins.to_i.zero? ? update(delayed: nil) : update(delayed: mins)
   end
 
   def humanize_delay
@@ -97,8 +97,8 @@ class Device < ApplicationRecord
 
   def notify_friends(data)
     Subscription.where(event: 'friend_new_checkin').where(subscriber_id: user.friends).each do |sub|
-      checkin = safe_checkin_info_for(permissible: sub.subscriber, type: 'address', action: 'last')[0]
-      next unless checkin && checkin['id'] == data['id']
+      checkin = safe_checkin_info_for(permissible: sub.subscriber, type: 'address', action: 'last').first
+      next unless checkin && checkin['id'] == data['id'] && user.changed_location?
       checkin.merge!(user.public_info.remove_id.as_json)
       sub.send_data([checkin])
     end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -99,6 +99,7 @@ class Device < ApplicationRecord
     Subscription.where(event: 'friend_new_checkin').where(subscriber_id: user.friends).each do |sub|
       checkin = safe_checkin_info_for(permissible: sub.subscriber, type: 'address', action: 'last').first
       next unless checkin && checkin['id'] == data['id'] && user.changed_location?
+      checkin.merge!(public_info.remove_id.as_json)
       checkin.merge!(user.public_info.remove_id.as_json)
       sub.send_data([checkin])
     end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -96,10 +96,9 @@ class Device < ApplicationRecord
   end
 
   def notify_friends(data)
-    user.friends.each do |friend|
-      next unless (sub = Subscription.where(event: 'friend_new_checkin').find_by(subscriber_id: friend.id))
+    Subscription.where(event: 'friend_new_checkin').where(subscriber_id: user.friends).each do |sub|
       checkin = safe_checkin_info_for(
-        permissible: friend,
+        permissible: sub.subscriber,
         type: 'address',
         action: 'last'
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,6 +110,14 @@ class User < ApplicationRecord
     subqueries.present? ? Checkin.where(subqueries.inject(&:or)) : Checkin.none
   end
 
+  def changed_location?
+    most_recent = checkins[0]
+    second_most_recent = checkins[1]
+    lat_diff = (most_recent.lat - second_most_recent.lat).abs
+    lng_diff = (most_recent.lng - second_most_recent.lng).abs
+    lat_diff > 0.001 || lng_diff > 0.001
+  end
+
   ##############
 
   def slack_message

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,20 +17,17 @@ class User < ApplicationRecord
   has_many :requests
   has_many :approvals, dependent: :destroy
   has_many :subscriptions, as: :subscriber, dependent: :destroy
-  has_many :developers, -> { where "status = 'accepted'" },
-           through: :approvals, source: :approvable, source_type: 'Developer'
-  has_many :developer_approvals, -> { where(status: 'accepted', approvable_type: 'Developer') },
-           class_name: 'Approval'
-  has_many :friends, -> { where "status = 'accepted'" },
-           through: :approvals, source: :approvable, source_type: 'User'
-  has_many :friend_approvals, -> { where(status: 'accepted', approvable_type: 'User') },
-           class_name: 'Approval'
-  has_many :pending_friends, -> { where "status = 'pending'" },
-           through: :approvals, source: :approvable, source_type: 'User'
-  has_many :friend_requests, -> { where "status = 'requested'" },
-           through: :approvals, source: :approvable, source_type: 'User'
-  has_many :developer_requests, -> { where "status = 'developer-requested'" },
-           through: :approvals, source: :approvable, source_type: 'Developer'
+  has_many :developers, -> { where "status = 'accepted'" }, through: :approvals, source: :approvable,
+                                                            source_type: 'Developer'
+  has_many :developer_approvals, -> { where(status: 'accepted', approvable_type: 'Developer') }, class_name: 'Approval'
+  has_many :friends, -> { where "status = 'accepted'" }, through: :approvals, source: :approvable, source_type: 'User'
+  has_many :friend_approvals, -> { where(status: 'accepted', approvable_type: 'User') }, class_name: 'Approval'
+  has_many :pending_friends, -> { where "status = 'pending'" }, through: :approvals, source: :approvable,
+                                                                source_type: 'User'
+  has_many :friend_requests, -> { where "status = 'requested'" }, through: :approvals, source: :approvable,
+                                                                  source_type: 'User'
+  has_many :developer_requests, -> { where "status = 'developer-requested'" }, through: :approvals, source: :approvable,
+                                                                               source_type: 'Developer'
   has_many :permissions, as: :permissible, dependent: :destroy
   has_many :permitted_devices, through: :permissions, source: :permissible, source_type: 'Device'
 
@@ -113,6 +110,7 @@ class User < ApplicationRecord
   def changed_location?
     most_recent = checkins[0]
     second_most_recent = checkins[1]
+    return true unless second_most_recent
     lat_diff = (most_recent.lat - second_most_recent.lat).abs
     lng_diff = (most_recent.lng - second_most_recent.lng).abs
     lat_diff > 0.001 || lng_diff > 0.001

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
   end
   let(:checkin) { FactoryGirl.create :checkin, device: device }
   let(:subscription) { FactoryGirl.create :subscription, subscriber: user }
+  let(:friend_sub) { FactoryGirl.create :subscription, subscriber: second_user, event: 'friend_new_checkin' }
   let(:create_headers) { request.headers['X-UUID'] = device.uuid }
   let(:address) { 'The Pilot Centre, Denham Aerodrome, Denham Aerodrome, Denham, Buckinghamshire UB9 5DF, UK' }
   let(:params) { { user_id: user.id, device_id: device.id } }
@@ -188,6 +189,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
   describe 'POST #create' do
     it 'should create a checkin when there is a pre-existing device' do
       subscription
+      friend_sub
       count = user.checkins.count
       create_headers
       post :create, params: create_params


### PR DESCRIPTION
When you create a checkin:
- checks whether any of your friends are subscribed to 'friend_new_checkin' event.
- checks if friend can view the checkin created. (delay, privilege)
- checks if you have moved since the checkin before.
- sends checkin info, device info and user info to friend via zapier.

Won't send any info if friend privilege is disallowed, if device is delayed, or if user has not moved.

Feels like a lot of code specifically for a zapier endpoint so feel free to take issue with this PR.