### PR TITLE
Default privilege

### DIFF
--- a/app/assets/javascripts/PermissionSwitch.es6
+++ b/app/assets/javascripts/PermissionSwitch.es6
@@ -28,7 +28,7 @@ class LocalSwitch extends PermissionSwitch {
     if (this.switchtype === "disallowed") {
       this.changeDisableSwitches(this.checked);
     }
-    if (this.switchtype === "last_only" && this.attributeState === "last_only") {
+    if (this.switchtype === "last_only" && this.checked === true && this.attributeState === 'last_only') {
       let result = confirm("WARNING: once you turn this on, it may be possible for your entire location history to be copied before you are able to turn it off again.\
         Only share your history with highly trusted parties. Click OK to continue anyway.");
       if(!result){
@@ -68,15 +68,23 @@ class MasterSwitch extends PermissionSwitch {
   }
 
   toggleSwitch() {
+    if (this.switchtype === "last_only" && this.checked === true) {
+      let result = confirm("WARNING: once you turn this on, it may be possible for your entire location history to be copied before you are able to turn it off again.\
+        Only share your history with highly trusted parties. Click OK to continue anyway.");
+      if(!result){
+        this.inputDomElement.prop("checked", !this.checked);
+        return;
+      }
+    }
     this.permissions.forEach(function(permission) {
       const P_DOM_ELEMENT = $(`div[data-id=${permission.id}][data-switchtype=${this.switchtype}].permission-switch`);
       const P_SWITCH = new LocalSwitch(this.user, P_DOM_ELEMENT, this.permissions, this.page);
       if ((P_SWITCH.disabled && P_SWITCH.switchtype === 'last_only')){
         this.inputDomElement.prop("checked", false)
       } else if (this.checked !== P_SWITCH.checked) {
-        P_SWITCH.inputDomElement.prop("checked", this.checked);
-        P_SWITCH.checked = this.checked;
         P_SWITCH.toggleSwitch();
+        P_SWITCH.checked = this.checked;
+        P_SWITCH.inputDomElement.prop("checked", this.checked);
       }
     }, this);
   }

--- a/app/assets/javascripts/PermissionSwitch.es6
+++ b/app/assets/javascripts/PermissionSwitch.es6
@@ -26,7 +26,8 @@ class LocalSwitch extends PermissionSwitch {
   toggleSwitch() {
     COPO.permissions.iconToggle(this.switchtype, this.id);
     if (this.switchtype === "disallowed") {
-      this.changeDisableSwitches(this.checked);
+      const bool = (this.attributeState != 'disallowed')
+      this.changeDisableSwitches(bool);
     }
     if (this.switchtype === "last_only" && this.checked === true && this.attributeState === 'last_only') {
       let result = confirm("WARNING: once you turn this on, it may be possible for your entire location history to be copied before you are able to turn it off again.\
@@ -47,7 +48,7 @@ class LocalSwitch extends PermissionSwitch {
 
   nextState() {
     if(this.attributeState === "disallowed") {
-      return "complete"
+      return "last_only"
     } else if(this.switchtype === "disallowed") {
       return "disallowed"
     } else if(this.attributeState === "complete") {

--- a/app/assets/javascripts/PermissionSwitch.es6
+++ b/app/assets/javascripts/PermissionSwitch.es6
@@ -28,6 +28,14 @@ class LocalSwitch extends PermissionSwitch {
     if (this.switchtype === "disallowed") {
       this.changeDisableSwitches(this.checked);
     }
+    if (this.switchtype === "last_only" && this.attributeState === "last_only") {
+      let result = confirm("WARNING: once you turn this on, it may be possible for your entire location history to be copied before you are able to turn it off again.\
+        Only share your history with highly trusted parties. Click OK to continue anyway.");
+      if(!result){
+        this.inputDomElement.prop("checked", !this.checked);
+        return;
+      }
+    }
     this.permission[this.attribute] = this.nextState();
     $.ajax({
       url: `/users/${this.user}/devices/${this.permission['device_id']}/permissions/${this.id}`,

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -28,7 +28,7 @@ module PermissionsHelper
 
   def permissions_check_box_value(permissionable, type)
     if permissionable.class == Permission
-      if %w(disallowed last_only).include? type
+      if %w(disallowed complete).include? type
         permissionable.privilege == type
       else
         permissionable[type]

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -2,7 +2,7 @@ class Permission < ApplicationRecord
   belongs_to :device
   belongs_to :permissible, polymorphic: true
 
-  before_create { |p| p.privilege = :complete }
+  before_create { |p| p.privilege = :last_only }
 
   enum privilege: [:disallowed, :last_only, :complete]
 end

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -24,7 +24,7 @@
     <label id="<%=permissions_label_id(permissionable, 'last-only')%>">
       <%= check_box_tag 'last_only','', permissions_check_box_value(permissionable, 'complete') %>
       <span class="lever"></span>
-      Last only/All checkins<%= permissions_for_all(permissionable) %>
+      Last checkin only/Full history<%= permissions_for_all(permissionable) %>
     </label>
   </div>
 </div>

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -22,9 +22,9 @@
   </div>
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
     <label id="<%=permissions_label_id(permissionable, 'last-only')%>">
-      <%= check_box_tag 'last_only','', permissions_check_box_value(permissionable, 'last_only') %>
+      <%= check_box_tag 'last_only','', permissions_check_box_value(permissionable, 'complete') %>
       <span class="lever"></span>
-      All checkins/Last only<%= permissions_for_all(permissionable) %>
+      Last only/All checkins<%= permissions_for_all(permissionable) %>
     </label>
   </div>
 </div>

--- a/app/views/welcome/help.html.erb
+++ b/app/views/welcome/help.html.erb
@@ -77,7 +77,7 @@
           E.g. you might decide that you want a particular friend to be able to see your exact location for a fogged device. You can achieve this by enabling 'bypass fogging' for that friend on that device. This will allow them alone to see the device's data location as if it were not fogged.
         </blockquote>
         <p>
-          All checkins/last only allows you control over whether the consumer can see all of the checkins for a device or just the most recent checkin. Fogging and delay still apply.
+          Last checkin only/Full history allows you control over whether the consumer can see just the most recent checkin for a device or all of it's checkins. Fogging and delay still apply.
         </p>
       </div>
     </div>

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     before do
       31.times do
         checkin = FactoryGirl.create :checkin
+        device.permission_for(developer).update(privilege: 'complete')
         device.checkins << checkin
       end
     end

--- a/spec/controllers/users/permissions_controller_spec.rb
+++ b/spec/controllers/users/permissions_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Users::PermissionsController, type: :controller do
           privilege: 'last_only'
         }
       }
-      expect(Permission.find(permission.id).privilege).to eq 'complete'
+      expect(Permission.find(permission.id).privilege).to eq 'last_only'
       expect(response).to redirect_to(root_path)
     end
   end

--- a/spec/helpers/permissions_helper_spec.rb
+++ b/spec/helpers/permissions_helper_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe PermissionsHelper, type: :helper do
     it 'should return a boolean value depending on if permissionable is a Permission depending on the type' do
       permission.update(privilege: 'disallowed', bypass_delay: false, bypass_fogging: true)
       expect(helper.permissions_check_box_value(permission, 'disallowed')).to eq true
-      expect(helper.permissions_check_box_value(permission, 'last_only')).to eq false
+      expect(helper.permissions_check_box_value(permission, 'complete')).to eq false
       expect(helper.permissions_check_box_value(permission, 'bypass_delay')).to eq false
       expect(helper.permissions_check_box_value(permission, 'bypass_fogging')).to eq true
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Device, type: :model do
   end
 
   it 'should get the privilege level for a developer' do
-    expect(device.permission_for(developer).privilege).to eq 'complete'
+    expect(device.permission_for(developer).privilege).to eq 'last_only'
   end
 
   describe 'slack' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe User, type: :model do
       Approval.accept(user, developer, 'Developer')
       expect(user.devices.first.developers.count).to be 1
       expect(user.devices.first.developers.first).to eq developer
-      expect(user.devices.first.permission_for(developer).privilege).to eq 'complete'
+      expect(user.devices.first.permission_for(developer).privilege).to eq 'last_only'
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe User, type: :model do
       end
 
       it 'should have device privileges by default' do
-        expect(user.devices.first.permission_for(developer).privilege).to eq 'complete'
+        expect(user.devices.first.permission_for(developer).privilege).to eq 'last_only'
       end
     end
   end


### PR DESCRIPTION
Changed default privilege level to last only.

Flipped switch so off = last only, on = full history.

Added confirm to local + master switch that warns the user of the danger of allowing full history.

Updated help page to reflect change. Fixed spec.