### PR TITLE
#4398, #4399, #4373 Api checkins index

### DIFF
--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -69,7 +69,6 @@ class Api::V1::CheckinsController < Api::ApiController
     per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
     checkins = @device ? @device.checkins : @user.checkins
     checkins = action_name == 'last' ? checkins.limit(1) : checkins.paginate(page: params[:page], per_page: per_page)
-    checkins = checkins.map(&:reverse_geocode!) if params[:type] == 'address'
-    checkins
+    params[:type] == 'address' ? checkins.map(&:reverse_geocode!) : checkins
   end
 end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -69,7 +69,7 @@ class Api::V1::CheckinsController < Api::ApiController
     per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
     checkins = @device ? @device.checkins : @user.checkins
     checkins = checkins.limit(1) if action_name == 'last'
-    checkins = params[:type] == 'address' ? checkins.map(&:reverse_geocode!) : checkins
+    checkins = checkins.map(&:reverse_geocode!) if params[:type] == 'address'
     checkins.paginate(page: params[:page], per_page: per_page)
   end
 end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -68,8 +68,8 @@ class Api::V1::CheckinsController < Api::ApiController
   def copo_app_checkins
     per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
     checkins = @device ? @device.checkins : @user.checkins
-    checkins = checkins.limit(1) if action_name == 'last'
-    checkins.map!(&:reverse_geocode!) if params[:type] == 'address'
-    checkins.paginate(page: params[:page], per_page: per_page)
+    checkins = action_name == 'last' ? checkins.limit(1) : checkins.paginate(page: params[:page], per_page: per_page)
+    checkins = checkins.map(&:reverse_geocode!) if params[:type] == 'address'
+    checkins
   end
 end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -6,35 +6,29 @@ class Api::V1::CheckinsController < Api::ApiController
   before_action :check_user_approved_approvable, :find_device, except: :create
 
   def index
-    if req_from_coposition_app?
-      checkins = copo_app_checkins
-    else
-      per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
-      checkins = @user.safe_checkin_info(
-        permissible: @permissible,
-        device: @device,
-        page: params[:page],
-        per_page: per_page,
-        type: params[:type],
-        action: action_name
-      )
-      unsanitized_checkins = @user.get_user_checkins_for(@permissible).paginate(page: params[:page], per_page: per_page)
-      paginated_response_headers(unsanitized_checkins)
-    end
+    per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
+    checkins = @user.safe_checkin_info(
+      copo_app: req_from_coposition_app?,
+      permissible: @permissible,
+      device: @device,
+      page: params[:page],
+      per_page: per_page,
+      type: params[:type],
+      action: action_name
+    )
+    unsanitized_checkins = @user.get_user_checkins_for(@permissible).paginate(page: params[:page], per_page: per_page)
+    paginated_response_headers(unsanitized_checkins)
     render json: checkins
   end
 
   def last
-    if req_from_coposition_app?
-      checkin = copo_app_checkins
-    else
-      checkin = @user.safe_checkin_info(
-        permissible: @permissible,
-        device: @device,
-        type: params[:type],
-        action: action_name
-      )
-    end
+    checkin = @user.safe_checkin_info(
+      copo_app: req_from_coposition_app?,
+      permissible: @permissible,
+      device: @device,
+      type: params[:type],
+      action: action_name
+    )
     render json: checkin
   end
 
@@ -52,9 +46,8 @@ class Api::V1::CheckinsController < Api::ApiController
   private
 
   def device_exists?
-    if (@device = Device.find_by(uuid: request.headers['X-UUID'])).nil?
-      render status: 400, json: { error: 'You must provide a valid uuid' }
-    end
+    return unless (@device = Device.find_by(uuid: request.headers['X-UUID'])).nil?
+    render status: 400, json: { error: 'You must provide a valid uuid' }
   end
 
   def allowed_params
@@ -63,12 +56,5 @@ class Api::V1::CheckinsController < Api::ApiController
 
   def find_device
     @device = Device.find(params[:device_id]) if params[:device_id]
-  end
-
-  def copo_app_checkins
-    per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
-    checkins = @device ? @device.checkins : @user.checkins
-    checkins = action_name == 'last' ? checkins.limit(1) : checkins.paginate(page: params[:page], per_page: per_page)
-    params[:type] == 'address' ? checkins.map(&:reverse_geocode!) : checkins
   end
 end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -66,8 +66,10 @@ class Api::V1::CheckinsController < Api::ApiController
   end
 
   def copo_app_checkins
+    per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
     checkins = @device ? @device.checkins : @user.checkins
     checkins = checkins.limit(1) if action_name == 'last'
-    params[:type] == 'address' ? checkins.map(&:reverse_geocode!) : checkins
+    checkins = params[:type] == 'address' ? checkins.map(&:reverse_geocode!) : checkins
+    checkins.paginate(page: params[:page], per_page: per_page)
   end
 end

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -69,7 +69,7 @@ class Api::V1::CheckinsController < Api::ApiController
     per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
     checkins = @device ? @device.checkins : @user.checkins
     checkins = checkins.limit(1) if action_name == 'last'
-    checkins = checkins.map(&:reverse_geocode!) if params[:type] == 'address'
+    checkins.map!(&:reverse_geocode!) if params[:type] == 'address'
     checkins.paginate(page: params[:page], per_page: per_page)
   end
 end

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -32,7 +32,11 @@ class Api::V1::Users::DevicesController < Api::ApiController
     device = @user.devices.where(id: params[:id]).first
     return unless device_exists? device
     device.update(device_params)
-    render json: { data: device, config: configuration(device) }
+    if device.save
+      render json: { data: device, config: configuration(device) }
+    else
+      render status: 400, json: { error: device.errors }
+    end
   end
 
   private

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,10 +25,15 @@ class Device < ApplicationRecord
   end
 
   def safe_checkin_info_for(args)
-    sanitized = permitted_history_for(args[:permissible]).limit_returned_checkins(args)
-    sanitized = sanitized.map(&:reverse_geocode!) if args[:type] == 'address'
-    sanitized = sanitized.map(&:replace_foggable_attributes) unless can_bypass_fogging?(args[:permissible])
-    sanitized.map(&:public_info)
+    if args[:copo_app]
+      sanitized = checkins.limit_returned_checkins(args)
+      args[:type] == 'address' ? sanitized.map(&:reverse_geocode!) : sanitized
+    else
+      sanitized = permitted_history_for(args[:permissible]).limit_returned_checkins(args)
+      sanitized = sanitized.map(&:reverse_geocode!) if args[:type] == 'address'
+      sanitized = sanitized.map(&:replace_foggable_attributes) unless can_bypass_fogging?(args[:permissible])
+      sanitized.map(&:public_info)
+    end
   end
 
   def permitted_history_for(permissible)

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -25,15 +25,12 @@ class Device < ApplicationRecord
   end
 
   def safe_checkin_info_for(args)
-    if args[:copo_app]
-      sanitized = checkins.limit_returned_checkins(args)
-      args[:type] == 'address' ? sanitized.map(&:reverse_geocode!) : sanitized
-    else
-      sanitized = permitted_history_for(args[:permissible]).limit_returned_checkins(args)
-      sanitized = sanitized.map(&:reverse_geocode!) if args[:type] == 'address'
-      sanitized = sanitized.map(&:replace_foggable_attributes) unless can_bypass_fogging?(args[:permissible])
-      sanitized.map(&:public_info)
-    end
+    sanitized = args[:copo_app] ? checkins : permitted_history_for(args[:permissible])
+    sanitized = sanitized.limit_returned_checkins(args)
+    sanitized = sanitized.map(&:reverse_geocode!) if args[:type] == 'address'
+    return sanitized if args[:copo_app]
+    sanitized = sanitized.map(&:replace_foggable_attributes) unless can_bypass_fogging?(args[:permissible])
+    sanitized.map(&:public_info)
   end
 
   def permitted_history_for(permissible)

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,6 @@ module Coposition
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
 
-    config.autoload_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join('lib')
   end
 end

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -105,6 +105,13 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
       expect(res_hash[:error]).to eq('Device does not exist')
     end
 
+    it 'should return an error if updating with same name as another device' do
+      user.devices << empty_device
+      put :update, params: device_params.merge(id: empty_device.id, device: { name: device.name })
+      expect(response.status).to eq(400)
+      expect(res_hash[:error]['name'][0]).to match 'already been taken'
+    end
+
     it 'should not allow you to update someone elses device' do
       put :update, params: {
         user_id: second_user.id, id: second_user.devices.last.id, device: { fogged: true }, format: :json


### PR DESCRIPTION
Removed copo_app_checkins from api checkins controller. Moved logic to safe_checkin_info.

Made device update return an error if device does not update successfully.

Using eager-load-paths instead of autoload.

http://blog.arkency.com/2014/11/dont-forget-about-eager-load-when-extending-autoload/