### PR TITLE
#4280, #4395 permissions friend vs. app + hide copo devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ public/system/*
 
 # Bower
 vendor/assets/bower_components
-
-# Secrets
-config/secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ public/system/*
 
 # Bower
 vendor/assets/bower_components
+
+# Secrets
+config/secrets.yml

--- a/app/assets/stylesheets/permissions.scss
+++ b/app/assets/stylesheets/permissions.scss
@@ -8,4 +8,14 @@
   .master label {
     color: black;
   }
+
+  .permissible-name {
+  	margin-left: 10px;
+  }
+
+  .permission-divider {
+    height: 5px;
+    background-color: grey;
+  }
 }
+

--- a/app/controllers/api/v1/users/permissions_controller.rb
+++ b/app/controllers/api/v1/users/permissions_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::Users::PermissionsController < Api::ApiController
 
   def index
     permissions = Permission.where(device_id: params[:device_id])
+                            .where.not(permissible_id: Developer.coposition_developers.select(:id))
     render json: permissions
   end
 
@@ -18,6 +19,7 @@ class Api::V1::Users::PermissionsController < Api::ApiController
 
   def update_all
     permissions = Permission.where(device_id: params[:device_id])
+                            .where.not(permissible_id: Developer.coposition_developers.select(:id))
     permissions.update_all(allowed_params.to_h)
     render json: permissions
   end

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -1,12 +1,9 @@
 module PermissionsHelper
+  include ApprovalsHelper
   def permissible_title(permissible)
     title_start = "<div class=\"valign-wrapper\">#{avatar_for(permissible)}"
     title_end = '</div>'
-    title = if permissible.class.to_s == 'Developer'
-              title_start + permissible.company_name.to_s + title_end
-            else
-              title_start + permissible.email.to_s + title_end
-            end
+    title = title_start + "<p class=\"permissible-name\">#{approvals_approvable_name(permissible)}</p>" + title_end
     title.html_safe
   end
 

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -50,4 +50,8 @@ class Developer < ApplicationRecord
     key = type[:coposition] ? 'coposition_api_key' : 'mobile_app_api_key'
     find_by(api_key: Rails.application.secrets[key])
   end
+
+  def self.coposition_developers
+    where(api_key: [Rails.application.secrets['coposition_api_key'], Rails.application.secrets['mobile_app_api_key']])
+  end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -5,4 +5,10 @@ class Permission < ApplicationRecord
   before_create { |p| p.privilege = :last_only }
 
   enum privilege: [:disallowed, :last_only, :complete]
+
+  def coposition_developer?
+    return false unless permissible_type == 'Developer'
+    key = Developer.find(permissible_id).api_key
+    key == Rails.application.secrets['coposition_api_key'] || key == Rails.application.secrets['mobile_app_api_key']
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,11 @@ class User < ApplicationRecord
     end
   end
 
+  def not_coposition_developers
+    copo_keys = [Rails.application.secrets['coposition_api_key'], Rails.application.secrets['mobile_app_api_key']]
+    developers.where('api_key NOT IN(?)', copo_keys)
+  end
+
   ## Devices
 
   def approve_devices(permissible)

--- a/app/presenters/users/approvals_presenter.rb
+++ b/app/presenters/users/approvals_presenter.rb
@@ -29,7 +29,7 @@ module Users
     end
 
     def users_approved
-      @approvable_type == 'Developer' ? @user.developers.public_info : @user.friends.public_info
+      @approvable_type == 'Developer' ? @user.not_coposition_developers.public_info : @user.friends.public_info
     end
 
     def users_requests

--- a/app/presenters/users/approvals_presenter.rb
+++ b/app/presenters/users/approvals_presenter.rb
@@ -26,6 +26,7 @@ module Users
 
     def permissions
       @devices.map { |device| device.permissions.where(permissible_type: @approvable_type) }.inject(:+)
+              .to_a.delete_if(&:coposition_developer?)
     end
 
     def users_approved

--- a/app/presenters/users/devices_presenter.rb
+++ b/app/presenters/users/devices_presenter.rb
@@ -45,7 +45,7 @@ module Users
         checkins: gon_index_checkins,
         current_user_id: @user.id,
         devices: @devices,
-        permissions: @devices.map(&:permissions).inject(:+)
+        permissions: @devices.map(&:permissions).inject(:+).to_a.delete_if(&:coposition_developer?)
       }
     end
 

--- a/app/presenters/users/permissions_presenter.rb
+++ b/app/presenters/users/permissions_presenter.rb
@@ -19,6 +19,10 @@ module Users
     def devices_index
       @device = Device.find(@params[:device_id])
       @permissions = @device.permissions.includes(:permissible).order(:permissible_type, :permissible_id).reverse
+      @permissions.delete_if do |permission|
+        coposition_developer? permission
+      end
+      @permissions
     end
 
     def approvals_index(from)
@@ -78,6 +82,12 @@ module Users
 
     def approvals_permissions(type)
       @devices.map { |device| device.permissions.where(permissible_type: type) }.inject(:+)
+    end
+
+    def coposition_developer?(permission)
+      return false unless permission.permissible_type == 'Developer'
+      key = Developer.find(permission.permissible_id).api_key
+      key == Rails.application.secrets['coposition_api_key'] || key == Rails.application.secrets['mobile_app_api_key']
     end
   end
 end

--- a/app/presenters/users/permissions_presenter.rb
+++ b/app/presenters/users/permissions_presenter.rb
@@ -18,7 +18,7 @@ module Users
 
     def devices_index
       @device = Device.find(@params[:device_id])
-      @permissions = @device.permissions.includes(:permissible).order(:permissible_type, :id)
+      @permissions = @device.permissions.includes(:permissible).order(:permissible_type, :permissible_id).reverse
     end
 
     def approvals_index(from)

--- a/app/views/users/dashboards/show.html.erb
+++ b/app/views/users/dashboards/show.html.erb
@@ -51,7 +51,7 @@
 
 <section id="dashboard-quicklinks">
   <p>
-    You have <%= pluralize(current_user.devices.count, 'device') %>, <%= pluralize(current_user.developers.count, 'app') %> and <%= pluralize(current_user.friends.count, 'friend') %>.
+    You have <%= pluralize(current_user.devices.count, 'device') %>, <%= pluralize(current_user.not_coposition_developers.count, 'app') %> and <%= pluralize(current_user.friends.count, 'friend') %>.
      You have <%= link_to(pluralize(current_user.developer_requests.count, 'app'), user_apps_path) %> and
     <%= link_to(pluralize(current_user.friend_requests.count, 'friend'), user_friends_path) %> awaiting your approval.
   </p>

--- a/app/views/users/permissions/index.js.erb
+++ b/app/views/users/permissions/index.js.erb
@@ -8,7 +8,7 @@
 $('.progress').remove()
 if($list.children().length===1) {
   $list.append(`
-    <% @presenter.permissions.each do |permission| %>
+    <% @presenter.permissions.each_with_index do |permission, i| %>
       <li class="collection-item row valign-wrapper">
         <div class='valign col s5'>
         <% if @presenter.device.present? %>
@@ -30,6 +30,9 @@ if($list.children().length===1) {
         </div>
         <%= render partial: "users/permissions/controls", object: permission, as: 'permissionable' %>
       </li>
+      <% if @presenter.permissions[i+1] && permission.permissible_type != @presenter.permissions[i+1].permissible_type %>
+        <div class="permission-divider"></div>
+      <% end %>
     <% end %>
   `);
   COPO.permissions.switchesOff();

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,6 +19,8 @@ development:
 test:
   secret_key_base: 2c895373f134e0f9c184b80c2e9a8e796bca2be9e9b0bd306b08d30adada497f328202760f0e3520387e525f2a76a596e033a92f8da73d45b6ea9ac6ec7bd136
   mobile_app_key: "this-is-a-mobile-app"
+  coposition_api_key: "this-is-a-coposition-api-key"
+  mobile_app_api_key: "this-is-a-mobile-app-api-key"
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/spec/controllers/users/permissions_controller_spec.rb
+++ b/spec/controllers/users/permissions_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Users::PermissionsController, type: :controller do
       it 'should assign device and device permissions' do
         get :index, params: { user_id: user.id, device_id: device.id, from: 'devices' }
         expect(assigns(:presenter).device).to eq device
-        expect(assigns(:presenter).permissions).to eq device.permissions
+        expect(assigns(:presenter).permissions).to match_array device.permissions
       end
     end
     context 'from apps page' do

--- a/spec/helpers/permissions_helper_spec.rb
+++ b/spec/helpers/permissions_helper_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe PermissionsHelper, type: :helper do
       expect { helper.permissible_title(developer) }.not_to raise_error
     end
 
-    it "should return html with the user's email if it's a user" do
-      expect(helper.permissible_title(user)).to match(user.email)
+    it "should return html with the user's shortened email or name if it's a user" do
+      expect(helper.permissible_title(user)).to match(user.username)
       expect(helper.permissible_title(user).class).to eq(safebuffer)
     end
 


### PR DESCRIPTION
Ordering friends first, putting divider between friends and apps. Also putting friends name/shortened email in permissions instead of full email.

Also hiding coposition developers from user. So not showing in device permissions, on apps page, on permissions api. Also not updating when using update_all anywhere. 