### PR TITLE
Fix pathing

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,9 @@ class ApplicationController < ActionController::Base
     @presenter = ::Users::ApprovalsPresenter.new(current_user, type)
     gon.push(@presenter.gon)
   end
+
+  def correct_url_user?
+    return if User.friendly.find(params[:user_id]) == current_user
+    redirect_to controller: params[:controller], action: params[:action], user_id: current_user.friendly_id
+  end
 end

--- a/app/controllers/users/approvals_controller.rb
+++ b/app/controllers/users/approvals_controller.rb
@@ -1,5 +1,6 @@
 class Users::ApprovalsController < ApplicationController
   before_action :authenticate_user!
+  before_action :correct_url_user?
 
   def new
     @approval = Approval.new

--- a/app/controllers/users/dashboards_controller.rb
+++ b/app/controllers/users/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class Users::DashboardsController < ApplicationController
   before_action :authenticate_user!
+  before_action :correct_url_user?
 
   def show
     @presenter = ::Users::DashboardsPresenter.new(current_user)

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -1,5 +1,6 @@
 class Users::DevicesController < ApplicationController
   before_action :authenticate_user!, except: :shared
+  before_action :correct_url_user?
   before_action :published?, only: :shared
   before_action :require_ownership, only: [:show, :destroy, :update]
 

--- a/app/controllers/users/friends_controller.rb
+++ b/app/controllers/users/friends_controller.rb
@@ -1,5 +1,6 @@
 class Users::FriendsController < ApplicationController
   before_action :friends?
+  before_action :correct_url_user?
 
   def show
     presenter = ::Users::FriendsPresenter.new(current_user, params, 'show')

--- a/spec/controllers/users/dashboards_controller_spec.rb
+++ b/spec/controllers/users/dashboards_controller_spec.rb
@@ -13,12 +13,20 @@ RSpec.describe Users::DashboardsController, type: :controller do
     user.devices << device
     user
   end
+  let(:second_user) { FactoryGirl.create :user }
+
 
   describe 'GET #show' do
     it 'should load metadata for dashboard page' do
       get :show, params: { user_id: user.id }
       expect((assigns :presenter).class).to eq(Users::DashboardsPresenter)
       expect((assigns :presenter).most_used_device).to eq device
+    end
+
+    it 'should redirect to correct url if wrong user_id provided' do
+      user
+      get :show, params: { user_id: second_user.id }
+      expect(response).to redirect_to(controller: 'users/dashboards', action:'show', user_id: user.friendly_id)
     end
   end
 end


### PR DESCRIPTION
If user is logged in but puts in another user_id into url they get redirected to the correct url. Before they got taken to the same page but the url was unchanged.
E.G. 
Original (tom logged in)
users/jack/dashboard = loaded tom's dashboard, url: users/jack/dashboard

Now (tom logged in)
users/jack/dashboard = loads tom's dashboard + url: users/tom/dashboard