### PR TITLE
Batch checkin

### DIFF
--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -1,9 +1,9 @@
 class Api::V1::CheckinsController < Api::ApiController
   respond_to :json
 
-  skip_before_action :find_user, only: :create
-  before_action :device_exists?, only: :create
-  before_action :check_user_approved_approvable, :find_device, except: :create
+  skip_before_action :find_user, only: [:create, :batch_create]
+  before_action :device_exists?, only: [:create, :batch_create]
+  before_action :check_user_approved_approvable, :find_device, except: [:create, :batch_create]
 
   def index
     per_page = params[:per_page].to_i <= 1000 ? params[:per_page] : 1000
@@ -40,6 +40,15 @@ class Api::V1::CheckinsController < Api::ApiController
       render json: { data: [checkin], config: config }
     else
       render status: 400, json: { error: 'You must provide a lat and lng' }
+    end
+  end
+
+  def batch_create
+    success = @device.checkins.batch_create(request.raw_post)
+    if success
+      render json: { success: 'checkins added' }, status: :created
+    else
+      render json: { failed: 'checkins not added' }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -46,9 +46,9 @@ class Api::V1::CheckinsController < Api::ApiController
   def batch_create
     success = @device.checkins.batch_create(request.raw_post)
     if success
-      render json: { success: 'checkins added' }, status: :created
+      render status: 200, json: { message: 'Checkins created' }
     else
-      render json: { failed: 'checkins not added' }, status: :unprocessable_entity
+      render status: 422, json: { error: 'Checkins not created' }
     end
   end
 

--- a/app/controllers/api/v1/checkins_controller.rb
+++ b/app/controllers/api/v1/checkins_controller.rb
@@ -46,9 +46,9 @@ class Api::V1::CheckinsController < Api::ApiController
   def batch_create
     success = @device.checkins.batch_create(request.raw_post)
     if success
-      render status: 200, json: { message: 'Checkins created' }
+      render json: { message: 'Checkins created' }, status: 200
     else
-      render status: 422, json: { error: 'Checkins not created' }
+      render json: { error: 'Checkins not created' }, status: 422
     end
   end
 

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -35,7 +35,8 @@ class Checkin < ApplicationRecord
     Checkin.transaction do
       JSON.parse(post_content).each do |checkin_hash|
         raise ActiveRecord::Rollback unless (checkin_hash.keys - %w(lat lng created_at fogged)).empty?
-        Checkin.create!(checkin_hash)
+        checkin = Checkin.create(checkin_hash)
+        raise ActiveRecord::Rollback unless checkin.save
       end
     end
   end

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -37,6 +37,7 @@ class Checkin < ApplicationRecord
         raise ActiveRecord::Rollback unless (checkin_hash.keys - %w(lat lng created_at fogged)).empty?
         checkin = Checkin.create(checkin_hash)
         raise ActiveRecord::Rollback unless checkin.save
+        checkin.device.notify_subscribers('new_checkin', checkin)
       end
     end
   end

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -34,6 +34,7 @@ class Checkin < ApplicationRecord
   def self.batch_create(post_content)
     Checkin.transaction do
       JSON.parse(post_content).each do |checkin_hash|
+        raise ActiveRecord::Rollback unless (checkin_hash.keys - %w(lat lng created_at fogged)).empty?
         Checkin.create!(checkin_hash)
       end
     end

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -34,8 +34,7 @@ class Checkin < ApplicationRecord
   def self.batch_create(post_content)
     Checkin.transaction do
       JSON.parse(post_content).each do |checkin_hash|
-        raise ActiveRecord::Rollback unless (checkin_hash.keys - %w(lat lng created_at fogged)).empty?
-        checkin = Checkin.create(checkin_hash)
+        checkin = Checkin.create(checkin_hash.slice('lat', 'lng', 'created_at', 'fogged'))
         raise ActiveRecord::Rollback unless checkin.save
         checkin.device.notify_subscribers('new_checkin', checkin)
       end

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -7,8 +7,8 @@ class Checkin < ApplicationRecord
   delegate :user, to: :device
 
   default_scope { order(created_at: :desc) }
-  scope :since, -> (date) { where('created_at > ?', date) }
-  scope :before, -> (date) { where('created_at < ?', date) }
+  scope :since, ->(date) { where('created_at > ?', date) }
+  scope :before, ->(date) { where('created_at < ?', date) }
 
   reverse_geocoded_by :lat, :lng do |obj, results|
     if results.present?
@@ -28,6 +28,14 @@ class Checkin < ApplicationRecord
       add_fogged_info
     else
       raise 'Checkin is not assigned to a device.' unless Rails.env.test?
+    end
+  end
+
+  def self.batch_create(post_content)
+    Checkin.transaction do
+      JSON.parse(post_content).each do |checkin_hash|
+        Checkin.create!(checkin_hash)
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,11 @@ Rails.application.routes.draw do
       resources :subscriptions, only: [:create, :destroy]
       resources :configs, only: [:index, :show, :update]
       resource :uuid, only: [:show]
-      resources :checkins, only: [:create]
+      resources :checkins, only: [:create] do
+        collection do
+          post :batch_create
+        end
+      end
       resources :developers, only: [:index, :show]
       resources :demo do
         collection do

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -233,13 +233,5 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       expect(response.status).to eq(422)
       expect(res_hash[:error]).to eq('Checkins not created')
     end
-
-    it 'should return 422 if you POST a checkin with extra params' do
-      create_headers
-      post :batch_create, body: [lat_lng.merge(fogged_area: 'London'), lat_lng, lat_lng].to_json,
-                          format: :json
-      expect(res_hash[:error]).to eq('Checkins not created')
-      expect(response.status).to eq(422)
-    end
   end
 end


### PR DESCRIPTION
Added an endpoint for creating several check-ins at once. 
`[
  {lat:10, lng:20, created_at: date, fogged: true},
  {lat:5,lng:15},
  {lat:0,lng:10}
]`