### PR TITLE
Fix friends page when privilege last only

### DIFF
--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -28,8 +28,9 @@ module Users
 
     def show_device_gon
       checkins = device_checkins
+      per_page = checkins.size < 1000 ? checkins.size : 1000
       {
-        checkins: checkins.paginate(page: 1, per_page: 1000),
+        checkins: checkins.paginate(page: 1, per_page: per_page),
         total: checkins.size
       }
     end


### PR DESCRIPTION
Paginate was removing the limit of only 1 checkin returned an instead attempting to return 1000.