### PR TITLE
Checkin tests

### DIFF
--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -23,8 +23,8 @@ class Users::DevicesController < ApplicationController
   end
 
   def shared
-    presenter = ::Users::DevicesPresenter.new(current_user, params, 'shared')
-    gon.push(presenter.shared_gon)
+    @presenter = ::Users::DevicesPresenter.new(current_user, params, 'shared')
+    gon.push(@presenter.shared_gon)
   end
 
   def info

--- a/app/controllers/users/friends_controller.rb
+++ b/app/controllers/users/friends_controller.rb
@@ -3,10 +3,10 @@ class Users::FriendsController < ApplicationController
   before_action :correct_url_user?
 
   def show
-    presenter = ::Users::FriendsPresenter.new(current_user, params, 'show')
-    @friend = presenter.friend
-    @devices = presenter.devices
-    gon.push(presenter.index_gon)
+    @presenter = ::Users::FriendsPresenter.new(current_user, params, 'show')
+    @friend = @presenter.friend
+    @devices = @presenter.devices
+    gon.push(@presenter.index_gon)
   end
 
   def show_device

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -16,7 +16,7 @@ class Checkin < ApplicationRecord
         obj.send("output_#{m}=", results.first.send(m)) if (column_names.include? m.to_s) && !obj.fogged
       end
     else
-      obj.update(address: 'No address available')
+      obj.update(address: 'Not yet geocoded')
     end
   end
 
@@ -48,8 +48,7 @@ class Checkin < ApplicationRecord
     if args[:action] == 'index' && args[:multiple_devices]
       all
     elsif args[:action] == 'index' && !args[:multiple_devices]
-      per_page = all.length > 1 ? args[:per_page] : 1
-      paginate(page: args[:page], per_page: per_page)
+      paginate(page: args[:page], per_page: args[:per_page])
     else
       limit(1)
     end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -40,9 +40,7 @@ class Device < ApplicationRecord
 
   def sanitize_checkins(sanitized, args)
     if args[:type] == 'address'
-      sanitized = sanitized.map(&:reverse_geocode!) unless args[:action] == 'index' && args[:multiple_devices]
-      # if only one checkin in relation geocoding would turn into array so needs to be converted back sometimes
-      sanitized = checkins.where(id: sanitized[0].id) if sanitized.class.to_s == 'Array'
+      sanitized.map(&:reverse_geocode!) unless args[:action] == 'index' && args[:multiple_devices]
     end
     return sanitized if args[:copo_app]
     replace_checkin_attributes(args[:permissible], sanitized)
@@ -67,7 +65,7 @@ class Device < ApplicationRecord
     return Checkin.none if privilege_for(permissible) == 'disallowed'
     return unresolved_checkins if unresolved_checkins.empty?
     if privilege_for(permissible) == 'last_only'
-      unresolved_checkins.limit(1)
+      unresolved_checkins.where(id: unresolved_checkins.first.id)
     else
       unresolved_checkins
     end

--- a/app/presenters/users/devices_presenter.rb
+++ b/app/presenters/users/devices_presenter.rb
@@ -31,7 +31,7 @@ module Users
 
     def shared
       @device = Device.find(@params[:id])
-      @checkin = @device.checkins.first
+      @checkin = @device.checkins.before(@device.delayed.to_i.minutes.ago).first
     end
 
     def info

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -31,16 +31,16 @@ module Users
 
     def show_device_gon
       checkins = device_checkins
-      per_page = checkins.size < 1000 ? checkins.size : 1000
       {
-        checkins: checkins.paginate(page: 1, per_page: per_page),
+        checkins: checkins.length > 1 ? checkins.paginate(page: 1, per_page: 1000) : checkins,
         total: checkins.size
       }
     end
 
     def show_checkins(params)
+      checkins = device_checkins
       {
-        checkins: device_checkins.paginate(page: params[:page], per_page: params[:per_page])
+        checkins: checkins.length > 1 ? checkins.paginate(page: params[:page], per_page: params[:per_page]) : checkins
       }
     end
 

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -4,6 +4,9 @@ module Users
     attr_reader :devices
     attr_reader :device
     attr_reader :show_checkins
+    # for tests, maybe a better way of doing this
+    attr_reader :show_device_gon
+    attr_reader :index_gon
 
     def initialize(user, params, action)
       @user = user
@@ -28,8 +31,9 @@ module Users
 
     def show_device_gon
       checkins = device_checkins
+      per_page = checkins.size < 1000 ? checkins.size : 1000
       {
-        checkins: checkins.paginate(page: 1, per_page: 1000),
+        checkins: checkins.paginate(page: 1, per_page: per_page),
         total: checkins.size
       }
     end

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -32,7 +32,7 @@ module Users
     def show_device_gon
       checkins = device_checkins
       {
-        checkins: checkins.length > 1 ? checkins.paginate(page: 1, per_page: 1000) : checkins,
+        checkins: checkins.paginate(page: 1, per_page: 1000),
         total: checkins.size
       }
     end
@@ -40,7 +40,7 @@ module Users
     def show_checkins(params)
       checkins = device_checkins
       {
-        checkins: checkins.length > 1 ? checkins.paginate(page: params[:page], per_page: params[:per_page]) : checkins
+        checkins: checkins.paginate(page: params[:page], per_page: params[:per_page])
       }
     end
 

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -38,9 +38,8 @@ module Users
     end
 
     def show_checkins(params)
-      checkins = device_checkins
       {
-        checkins: checkins.paginate(page: params[:page], per_page: params[:per_page])
+        checkins: device_checkins.paginate(page: params[:page], per_page: params[:per_page])
       }
     end
 

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -155,6 +155,11 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         expect(response.header['X-Per-Page']).to eq '30'
         expect(res_hash.size).to eq 30
       end
+
+      it 'should geocode all checkins with type address' do
+        get :index, params: geocode_params
+        expect(res_hash.first['address']).to match 'The Pilot Centre'
+      end
     end
 
     context 'with page param' do
@@ -194,11 +199,6 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
         get :index, params: params
         expect(res_hash.first.keys).to eq checkin.attributes.keys
         expect(res_hash.first['id']).to be checkin.id
-      end
-
-      it 'should geocode all checkins with type address' do
-        get :index, params: geocode_params
-        expect(res_hash.first['address']).to match 'The Pilot Centre'
       end
 
       it 'should ignore fogging by default' do

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -159,6 +159,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
       it 'should geocode all checkins with type address' do
         get :index, params: geocode_params
         expect(res_hash.first['address']).to match 'The Pilot Centre'
+        expect(res_hash.last['address']).to match 'The Pilot Centre'
       end
     end
 

--- a/spec/controllers/users/dashboards_controller_spec.rb
+++ b/spec/controllers/users/dashboards_controller_spec.rb
@@ -14,7 +14,21 @@ RSpec.describe Users::DashboardsController, type: :controller do
     user
   end
   let(:second_user) { FactoryGirl.create :user }
+  let(:friend_device) { FactoryGirl.create :device, user_id: second_user.id, delayed: 10 }
+  let(:checkin) { FactoryGirl.create :checkin, device: friend_device }
+  let(:historic_checkin) { FactoryGirl.create :checkin, device: friend_device, created_at: Time.now - 1.day }
+  let(:approval) do
+    device
+    Approval.link(user, second_user, 'User')
+    Approval.accept(second_user, user, 'User')
+  end
 
+  before do
+    approval
+    device
+    checkin
+    historic_checkin
+  end
 
   describe 'GET #show' do
     it 'should load metadata for dashboard page' do
@@ -26,7 +40,33 @@ RSpec.describe Users::DashboardsController, type: :controller do
     it 'should redirect to correct url if wrong user_id provided' do
       user
       get :show, params: { user_id: second_user.id }
-      expect(response).to redirect_to(controller: 'users/dashboards', action:'show', user_id: user.friendly_id)
+      expect(response).to redirect_to(controller: 'users/dashboards', action: 'show', user_id: user.friendly_id)
+    end
+
+    context 'permission disallowed' do
+      it 'should render no checkins' do
+        friend_device.permission_for(user).update! privilege: 'disallowed'
+        get :show, params: { user_id: user.id }
+        expect((assigns :presenter).gon[:friends][0][:lastCheckin]).to be nil
+      end
+    end
+
+    context 'permission complete, bypass delay false, bypass fogging false' do
+      it 'should render one historic fogged checkin' do
+        friend_device.permission_for(user).update! privilege: 'complete', bypass_delay: false, bypass_fogging: false
+        get :show, params: { user_id: user.id }
+        checkins = (assigns :presenter).gon[:friends][0][:lastCheckin]
+        expect(checkins['lat'].round(6)).to eq historic_checkin.fogged_lat.round(6)
+        expect(checkins['id']).to eq historic_checkin.id
+      end
+    end
+
+    context 'permission complete, bypass delay true, bypass fogging true' do
+      it 'should render one recent unfogged checkin' do
+        friend_device.permission_for(user).update! privilege: 'complete', bypass_delay: true, bypass_fogging: true
+        get :show, params: { user_id: user.id }
+        expect((assigns :presenter).gon[:friends][0][:lastCheckin]['lat'].round(6)).to eq checkin.lat.round(6)
+      end
     end
   end
 end

--- a/spec/controllers/users/friends_controller_spec.rb
+++ b/spec/controllers/users/friends_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Users::FriendsController, type: :controller do
     end
 
     context 'permission complete, bypass delay true, bypass fogging true' do
-      it 'should render two unfogged checkins' do
+      it 'should render one recent fogged checkin' do
         device.permission_for(user).update! privilege: 'complete', bypass_delay: true, bypass_fogging: true
         get :show, params: params
         expect((assigns :presenter).index_gon[:checkins][0]['lat'].round(6)).to eq checkin.lat.round(6)

--- a/spec/controllers/users/friends_controller_spec.rb
+++ b/spec/controllers/users/friends_controller_spec.rb
@@ -5,24 +5,60 @@ RSpec.describe Users::FriendsController, type: :controller do
 
   let(:user) { create_user }
   let(:second_user) { FactoryGirl.create :user }
-  let(:device) { FactoryGirl.create :device, user_id: second_user.id }
+  let(:device) { FactoryGirl.create :device, user_id: second_user.id, delayed: 10 }
   let(:checkin) { FactoryGirl.create :checkin, device: device }
+  let(:historic_checkin) { FactoryGirl.create :checkin, device: device, created_at: Time.now - 1.day }
   let(:approval) do
     device
     Approval.link(user, second_user, 'User')
     Approval.accept(second_user, user, 'User')
   end
-  let(:params) { { id: second_user.id, user_id: user.id, checkin_id: checkin.id, device_id: device.id } }
+  let(:params) { { id: second_user.id, user_id: user.id, device_id: device.id } }
+
+  before do
+    approval
+    device
+    checkin
+    historic_checkin
+  end
 
   describe 'GET #show' do
     it 'should assign @friend and friends devices if friends' do
-      approval
       get :show, params: params
       expect(assigns(:friend)).to eq(second_user)
       expect(assigns(:devices)).to eq(second_user.devices)
     end
 
+    context 'permission disallowed' do
+      it 'should render no checkins' do
+        device.permission_for(user).update! privilege: 'disallowed'
+        get :show, params: params
+        expect((assigns :presenter).index_gon[:checkins].size).to eq 0
+      end
+    end
+
+    context 'permission complete, bypass delay false, bypass fogging false' do
+      it 'should render one historic fogged checkin' do
+        device.permission_for(user).update! privilege: 'complete', bypass_delay: false, bypass_fogging: false
+        get :show, params: params
+        checkins = (assigns :presenter).index_gon[:checkins]
+        expect(checkins.size).to eq 1
+        expect(checkins[0]['lat'].round(6)).to eq historic_checkin.fogged_lat.round(6)
+        expect(checkins[0]['id']).to eq historic_checkin.id
+      end
+    end
+
+    context 'permission complete, bypass delay true, bypass fogging true' do
+      it 'should render two unfogged checkins' do
+        device.permission_for(user).update! privilege: 'complete', bypass_delay: true, bypass_fogging: true
+        get :show, params: params
+        expect((assigns :presenter).index_gon[:checkins][0]['lat'].round(6)).to eq checkin.lat.round(6)
+        expect((assigns :presenter).index_gon[:checkins].size).to eq 1
+      end
+    end
+
     it 'should say that you are not friends with user' do
+      Approval.all.destroy_all
       get :show, params: params
       expect(flash[:notice]).to match 'not friends'
     end
@@ -30,9 +66,54 @@ RSpec.describe Users::FriendsController, type: :controller do
 
   describe 'GET #show_device' do
     it 'should render the show device page' do
-      approval
       get :show_device, params: params
       expect(response.code).to eq '200'
+    end
+
+    context 'permission disallowed' do
+      it 'should render no checkins' do
+        device.permission_for(user).update! privilege: 'disallowed'
+        get :show_device, params: params
+        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 0
+      end
+    end
+
+    context 'permission last_only, bypass delay false' do
+      it 'should render one historic_checkin' do
+        device.permission_for(user).update! privilege: 'last_only', bypass_delay: false
+        get :show_device, params: params
+        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 1
+        expect((assigns :presenter).show_device_gon[:checkins][0]['id']).to eq historic_checkin.id
+      end
+    end
+
+    context 'permission last_only, bypass delay true' do
+      it 'should render one recent checkin' do
+        device.permission_for(user).update! privilege: 'last_only', bypass_delay: true
+        get :show_device, params: params
+        expect((assigns :presenter).show_device_gon[:checkins][0]['id']).to eq checkin.id
+        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 1
+      end
+    end
+
+    context 'permission complete, bypass delay false, bypass fogging false' do
+      it 'should render one historic fogged checkin' do
+        device.permission_for(user).update! privilege: 'complete', bypass_delay: false, bypass_fogging: false
+        get :show_device, params: params
+        checkins = (assigns :presenter).show_device_gon[:checkins]
+        expect(checkins[0]['id']).to eq historic_checkin.id
+        expect(checkins[0]['lat'].round(6)).to eq historic_checkin.fogged_lat.round(6)
+        expect(checkins.size).to eq 1
+      end
+    end
+
+    context 'permission complete, bypass delay true, bypass fogging true' do
+      it 'should render two unfogged checkins' do
+        device.permission_for(user).update! privilege: 'complete', bypass_delay: true, bypass_fogging: true
+        get :show_device, params: params
+        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 2
+        expect((assigns :presenter).show_device_gon[:checkins][0]['lat'].round(6)).to eq checkin.lat.round(6)
+      end
     end
   end
 end


### PR DESCRIPTION
Checking correct check-in(s) shown on:
 - Friends show/show_device
 - Dashboard
 - Device shared page
Changed from using limit to using where(id: checkin.id) in limit_returned_checkins so that paginating check-ins down the line does not have any adverse effects (remove limit).
