### PR TITLE
update-published

### DIFF
--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -46,7 +46,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
   end
 
   def device_params
-    params.require(:device).permit(:name, :uuid, :fogged, :delayed, :alias)
+    params.require(:device).permit(:name, :uuid, :fogged, :delayed, :published, :alias)
   end
 
   def configuration(device)


### PR DESCRIPTION
Currently can't update device.published via the API, not sure if there's a reason for this but would like to be able to do so so I can switch sharing on/off from the app.