### PR TITLE
weird-query

### DIFF
--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -100,11 +100,8 @@ class Checkin < ApplicationRecord
   end
 
   def self.unique_places_only(unique_places)
-    # doesn't work so making it always return all for now
-    return all # unless unique_places
-    checkins = unscope(:order).select('DISTINCT ON (checkins.fogged_city) *')
-                              .sort { |checkin, next_checkin| next_checkin['created_at'] <=> checkin['created_at'] }
-    all.where(id: checkins.map(&:id))
+    return all unless unique_places
+    where('created_at IN(SELECT MAX(created_at) FROM checkins GROUP BY fogged_city)')
   end
 
   def self.hash_group_and_count_by(attribute)
@@ -174,5 +171,5 @@ class Checkin < ApplicationRecord
       geojson_checkins << GeojsonCheckin.new(checkin)
     end
     geojson_checkins.as_json
-  end
+  end    
 end

--- a/app/presenters/users/dashboards_presenter.rb
+++ b/app/presenters/users/dashboards_presenter.rb
@@ -16,7 +16,7 @@ module Users
       @percent_change = @checkins.percentage_increase('week')
       @weeks_checkins_count = weeks_checkins.count
       @most_used = most_used_device
-      # @last_countries_loaded = last_countries
+      @last_countries_loaded = last_countries
     end
 
     def most_used_device
@@ -24,16 +24,7 @@ module Users
     end
 
     def last_countries
-      # doesn't work currently, returns wrong countries.
-      @checkins.select('distinct(country_code)', 'id', 'created_at').sort.reverse.uniq(&:country_code)
-               .select { |c| c.country_code != 'No Country' }.first(10)
-               .sort_by(&:created_at).reverse
-               .map do |checkin|
-        {
-          country_code: checkin.country_code,
-          last_visited: checkin.created_at
-        }
-      end
+      @checkins.where('created_at IN(SELECT MAX(created_at) FROM checkins GROUP BY country_code)').first 10
     end
 
     def gon

--- a/app/views/users/dashboards/show.html.erb
+++ b/app/views/users/dashboards/show.html.erb
@@ -43,7 +43,7 @@
     <tbody>
     <% @presenter.last_countries_loaded.each do |country| %>
       <tr>
-        <td><%= dashboard_flag(country[:country_code]) %></td><td ><%= dashboard_country_name(country[:country_code]) %></td><td><%= humanize_date(country[:last_visited]) %></td>
+        <td><%= dashboard_flag(country[:country_code]) %></td><td ><%= dashboard_country_name(country[:country_code]) %></td><td><%= humanize_date(country[:created_at]) %></td>
       </tr>
     <% end %>
     </tbody>

--- a/spec/controllers/api/v1/users/checkins_controller_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
     end
 
     context 'with unique places param' do
-      it 'should return only unique fogged area checkins', skip: true do
+      it 'should return only unique fogged area checkins' do
         get :index, params: params.merge(unique_places: true)
         expect(res_hash.size).to eq 1
       end


### PR DESCRIPTION
Fixed unique places and last countries, main slow query is now user.safe_checkin_info_for(args) due to the sort_by but not sure how we can avoid this as individual filtering has to occur on each device so can't just do one big query.