### PR TITLE
Device page improvements

### DIFF
--- a/app/assets/javascripts/devices/devices-show.js
+++ b/app/assets/javascripts/devices/devices-show.js
@@ -84,7 +84,9 @@ $(document).on('page:change', function() {
           });
           request
           .done(function (response) {
-            _.find(gon.checkins, _.matchesProperty('id',response.id))[type] = parseFloat(newCoord);
+            checkin = _.find(gon.checkins, _.matchesProperty('id',response.id));
+            checkin[type] = parseFloat(newCoord);
+            checkin.center = true;
             M.queueRefresh(gon.checkins);
           })
           .fail(function (error) {

--- a/app/assets/javascripts/devices/devices-show.js
+++ b/app/assets/javascripts/devices/devices-show.js
@@ -86,7 +86,7 @@ $(document).on('page:change', function() {
           .done(function (response) {
             checkin = _.find(gon.checkins, _.matchesProperty('id',response.id));
             checkin[type] = parseFloat(newCoord);
-            checkin.center = true;
+            checkin.edited = true;
             M.queueRefresh(gon.checkins);
           })
           .fail(function (error) {

--- a/app/assets/javascripts/maps.es6
+++ b/app/assets/javascripts/maps.es6
@@ -364,6 +364,9 @@ window.COPO.maps = {
       alt: 'ID: ' + checkin.id,
       checkin: checkin
     }
+    if(checkin.center){
+      map.panTo([checkin.lat, checkin.lng]);
+    }
     markerOptions = $.extend({}, defaults, markerOptions)
     return L.marker([checkin.lat, checkin.lng], markerOptions)
   },

--- a/app/assets/javascripts/maps.es6
+++ b/app/assets/javascripts/maps.es6
@@ -364,7 +364,7 @@ window.COPO.maps = {
       alt: 'ID: ' + checkin.id,
       checkin: checkin
     }
-    if(checkin.center){
+    if(checkin.edited){
       map.panTo([checkin.lat, checkin.lng]);
     }
     markerOptions = $.extend({}, defaults, markerOptions)

--- a/app/assets/javascripts/utility.es6.erb
+++ b/app/assets/javascripts/utility.es6.erb
@@ -41,7 +41,7 @@ COPO.utility = {
   },
 
   updateCheckinSpan(checkin, type) {
-    return $('<span href="' + window.location.pathname + '/checkins/' + checkin.id + '"><span class="editable">' + checkin[type] + '</span><i class="material-icons grey-text edit-' + type + '">mode_edit</i>&nbsp;</span>').prop('outerHTML')
+    return $('<span href="' + window.location.pathname + '/checkins/' + checkin.id + '"><span class="editable">' + checkin[type].toFixed(6) + '</span><i class="material-icons grey-text edit-' + type + '">mode_edit</i>&nbsp;</span>').prop('outerHTML')
   },
 
   geocodeCheckinLink(checkin) {

--- a/app/controllers/users/checkins_controller.rb
+++ b/app/controllers/users/checkins_controller.rb
@@ -36,6 +36,7 @@ class Users::CheckinsController < ApplicationController
     @checkin = Checkin.find(params[:id])
     if params[:checkin]
       @checkin.update(allowed_params)
+      @checkin.refresh
       return render status: 200, json: @checkin unless @checkin.errors.any?
       render status: 400, json: @checkin.errors.messages
     else

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -70,6 +70,13 @@ class Checkin < ApplicationRecord
     City.near([lat, lng], 200).first || NoCity.new
   end
 
+  def refresh
+    reverse_geocode
+    save
+    init_fogged_info
+    fogged || device.fogged ? set_output_to_fogged : set_output_to_unfogged
+  end
+
   def init_fogged_info
     update(
       fogged_lat: nearest_city.latitude || lat + rand(-0.5..0.5),

--- a/app/views/users/checkins/show.js.erb
+++ b/app/views/users/checkins/show.js.erb
@@ -3,3 +3,6 @@ checkin.address = '<%= j @checkin.address %>'
 
 var $geocodedAddress = '<li class="address">Address: <%= j @checkin.address %></li>'
 $('.address').replaceWith($geocodedAddress);
+
+var $foggedAddress = '<li class="foggedAddress">Fogged address: <%= j @checkin.fogged_city %></li>'
+$('.foggedAddress').replaceWith($foggedAddress);


### PR DESCRIPTION
Rounding checkin lat/lng to 6 decimal places.

Added a refresh method that updates fogging info, output info, geocoded address after you update the latitude/longitude of a checkin.

Making sure to replace fogged address as well as address when viewing a checkin you have just edited.

Centering map on an edited checkins new location after its marker moves to the new coords.