### PR TITLE
fog-device

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -105,7 +105,6 @@ class Device < ApplicationRecord
 
   def switch_fog
     update(fogged: !fogged)
-    system "rake checkins:update_output[#{id}] &"
     fogged
   end
 


### PR DESCRIPTION
Deleted call to rake task that updates past check-ins, so when you fog a device, check-ins that were created whilst it was unfogged will remain unfogged.