### PR TITLE
Edited checkin

### DIFF
--- a/app/assets/javascripts/devices/devices-show.js
+++ b/app/assets/javascripts/devices/devices-show.js
@@ -86,7 +86,7 @@ $(document).on('page:change', function() {
           .done(function (response) {
             checkin = _.find(gon.checkins, _.matchesProperty('id',response.id));
             checkin[type] = parseFloat(newCoord);
-            checkin.edited = true;
+            checkin.lastEdited = true;
             M.queueRefresh(gon.checkins);
           })
           .fail(function (error) {

--- a/app/assets/javascripts/devices/devices-show.js
+++ b/app/assets/javascripts/devices/devices-show.js
@@ -86,6 +86,7 @@ $(document).on('page:change', function() {
           .done(function (response) {
             checkin = _.find(gon.checkins, _.matchesProperty('id',response.id));
             checkin[type] = parseFloat(newCoord);
+            checkin.edited = true;
             checkin.lastEdited = true;
             M.queueRefresh(gon.checkins);
           })

--- a/app/assets/javascripts/maps.es6
+++ b/app/assets/javascripts/maps.es6
@@ -177,6 +177,7 @@ window.COPO.maps = {
         return `<a href="${window.location.pathname}/show_device?device_id=${checkin.device_id}" title="Device map">${checkin.device}</a>`
       }
     }
+    checkinTemp.edited = checkin.edited ? '(edited)' : ''
     checkinTemp.inlineLat = COPO.utility.updateCheckinSpan(checkin, 'lat');
     checkinTemp.inlineLng = COPO.utility.updateCheckinSpan(checkin, 'lng');
     checkinTemp.foggle = COPO.utility.fogCheckinLink(checkin, foggedClass, 'fog');

--- a/app/assets/javascripts/maps.es6
+++ b/app/assets/javascripts/maps.es6
@@ -365,8 +365,9 @@ window.COPO.maps = {
       alt: 'ID: ' + checkin.id,
       checkin: checkin
     }
-    if(checkin.edited){
+    if(checkin.lastEdited){
       map.panTo([checkin.lat, checkin.lng]);
+      checkin.lastEdited = false;
     }
     markerOptions = $.extend({}, defaults, markerOptions)
     return L.marker([checkin.lat, checkin.lng], markerOptions)

--- a/app/controllers/users/checkins_controller.rb
+++ b/app/controllers/users/checkins_controller.rb
@@ -35,6 +35,7 @@ class Users::CheckinsController < ApplicationController
   def update
     @checkin = Checkin.find(params[:id])
     if params[:checkin]
+      @checkin.update(edited: true)
       @checkin.update(allowed_params)
       @checkin.refresh
       return render status: 200, json: @checkin unless @checkin.errors.any?

--- a/app/controllers/users/checkins_controller.rb
+++ b/app/controllers/users/checkins_controller.rb
@@ -35,7 +35,6 @@ class Users::CheckinsController < ApplicationController
   def update
     @checkin = Checkin.find(params[:id])
     if params[:checkin]
-      @checkin.update(edited: true)
       @checkin.update(allowed_params)
       @checkin.refresh
       return render status: 200, json: @checkin unless @checkin.errors.any?

--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -9,6 +9,8 @@ class Checkin < ApplicationRecord
   scope :since, ->(date) { where('created_at > ?', date) }
   scope :before, ->(date) { where('created_at < ?', date) }
 
+  before_update :set_edited, if: proc { lat_changed? || lng_changed? }
+
   reverse_geocoded_by :lat, :lng do |obj, results|
     if results.present?
       results.first.methods.each do |m|
@@ -187,5 +189,9 @@ class Checkin < ApplicationRecord
       geojson_checkins << GeojsonCheckin.new(checkin)
     end
     geojson_checkins.as_json
-  end    
+  end
+
+  def set_edited
+    write_attribute(:edited, true)
+  end
 end

--- a/app/presenters/users/devices_presenter.rb
+++ b/app/presenters/users/devices_presenter.rb
@@ -83,7 +83,7 @@ module Users
 
     def show_checkins
       @device.checkins.paginate(page: 1, per_page: 1000)
-             .select(:id, :lat, :lng, :created_at, :address, :fogged, :fogged_city)
+             .select(:id, :lat, :lng, :created_at, :address, :fogged, :fogged_city, :edited)
     end
   end
 end

--- a/app/views/users/checkins/show.js.erb
+++ b/app/views/users/checkins/show.js.erb
@@ -6,3 +6,5 @@ $('.address').replaceWith($geocodedAddress);
 
 var $foggedAddress = '<li class="foggedAddress">Fogged address: <%= j @checkin.fogged_city %></li>'
 $('.foggedAddress').replaceWith($foggedAddress);
+
+$('.tooltipped').tooltip({delay: 50});

--- a/app/views/users/devices/show.html.erb
+++ b/app/views/users/devices/show.html.erb
@@ -12,7 +12,7 @@
 
   <!-- templates -->
   <script type="x-tmpl-mustache" id="markerPopupTmpl">
-    <h3 id="checkin{{id}}">ID: {{ id }}  <i class="tooltipped" data-tooltip="Latitude/longitude have been changed from original values">{{ edited }}</i></h3>
+    <h3>ID: {{ id }}  <i class="tooltipped" data-tooltip="Latitude/longitude have been changed from original values">{{ edited }}</i></h3>
     <ul>
       <li>Created on: {{ created_at }}</li>
       <li>Latitude: {{ &inlineLat }}</li>

--- a/app/views/users/devices/show.html.erb
+++ b/app/views/users/devices/show.html.erb
@@ -12,7 +12,7 @@
 
   <!-- templates -->
   <script type="x-tmpl-mustache" id="markerPopupTmpl">
-    <h3>ID: {{ id }}</h3>
+    <h3>ID: {{ id }}  <i>{{ edited }}</i></h3>
     <ul>
       <li>Created on: {{ created_at }}</li>
       <li>Latitude: {{ &inlineLat }}</li>

--- a/app/views/users/devices/show.html.erb
+++ b/app/views/users/devices/show.html.erb
@@ -12,7 +12,7 @@
 
   <!-- templates -->
   <script type="x-tmpl-mustache" id="markerPopupTmpl">
-    <h3>ID: {{ id }}  <i>{{ edited }}</i></h3>
+    <h3 id="checkin{{id}}">ID: {{ id }}  <i class="tooltipped" data-tooltip="Latitude/longitude have been changed from original values">{{ edited }}</i></h3>
     <ul>
       <li>Created on: {{ created_at }}</li>
       <li>Latitude: {{ &inlineLat }}</li>

--- a/db/migrate/20170109132911_add_edited_to_checkins.rb
+++ b/db/migrate/20170109132911_add_edited_to_checkins.rb
@@ -1,0 +1,5 @@
+class AddEditedToCheckins < ActiveRecord::Migration[5.0]
+  def change
+    add_column :checkins, :edited, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161110113344) do
+ActiveRecord::Schema.define(version: 20170109132911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20161110113344) do
     t.string   "output_postal_code"
     t.string   "output_country_code"
     t.string   "fogged_country_code"
+    t.boolean  "edited",              default: false
     t.index ["device_id"], name: "index_checkins_on_device_id", using: :btree
   end
 


### PR DESCRIPTION
Added new attribute edited to checkins, default false.
Edited set to true if lat or lng changed.
If checkin edited this is shown on checkin marker on device show page.

Also had to change js which panned to most recently updated checkin to stop map from panning to just any edited checkin, making sure only pans to checkin that was just updated.