### PR TITLE
Cloak device

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,8 +461,8 @@ DEPENDENCIES
   devise
   factory_girl_rails
   faker
-  friendly_id (~> 5.2.0)
   foreman
+  friendly_id (~> 5.2.0)
   geocoder
   gon (~> 6.1.0)
   gpx

--- a/app/assets/javascripts/PermissionSwitch.es6
+++ b/app/assets/javascripts/PermissionSwitch.es6
@@ -27,17 +27,14 @@ class LocalSwitch extends PermissionSwitch {
   toggleSwitch() {
     if (this.switchtype === "disallowed") {
       const bool = (this.attributeState != 'disallowed')
-      //this.changeDisableSwitches(bool);
     }
-    if (this.switchtype === "complete") {
+    if (this.switchtype === "complete" && this.checked) {
       let result = confirm(this.fullHistWarning);
       if(!result){
         $(`div[data-id=${this.id}][data-switchtype=${this.attributeState}].permission-switch`).find('input').prop("checked", true);
-        //this.inputDomElement.prop("checked", true);
         return;
       }
     }
-    COPO.permissions.iconToggle(this.switchtype, this.id);
     this.permission[this.attribute] = this.nextState();
     $.ajax({
       url: `/users/${this.user}/devices/${this.permission['device_id']}/permissions/${this.id}`,
@@ -93,11 +90,5 @@ class MasterSwitch extends PermissionSwitch {
     }, this)
     const NEW_MASTER_CHECKED_STATE = _.every(SWITCHES_CHECKED)
     this.inputDomElement.prop("checked", NEW_MASTER_CHECKED_STATE)
-
-    if (this.switchtype === "disallowed") {
-      //$(`div[data-id=${this.id}][data-switchtype=last_only].master`).find('input').prop("checked", false);
-      //const MASTERS = $(`div[data-id=${this.id}].disable.master`).find('input');
-      //MASTERS.prop("disabled", NEW_MASTER_CHECKED_STATE);
-    }
   }
 }

--- a/app/assets/javascripts/PermissionSwitch.es6
+++ b/app/assets/javascripts/PermissionSwitch.es6
@@ -8,7 +8,6 @@ class PermissionSwitch {
     this.checked = this.inputDomElement.prop('checked');
     this.disabled = this.inputDomElement.prop('disabled');
     this.fullHistWarning = "WARNING: once you turn this on, it may be possible for your entire location history to be copied before you are able to turn it off again. Only share your history with highly trusted parties. Click OK to continue anyway."
-
   }
 
   changeDisableSwitches(state) {
@@ -26,18 +25,19 @@ class LocalSwitch extends PermissionSwitch {
   }
 
   toggleSwitch() {
-    COPO.permissions.iconToggle(this.switchtype, this.id);
     if (this.switchtype === "disallowed") {
       const bool = (this.attributeState != 'disallowed')
-      this.changeDisableSwitches(bool);
+      //this.changeDisableSwitches(bool);
     }
-    if (this.switchtype === "last_only" && this.checked === true && this.attributeState === 'last_only') {
+    if (this.switchtype === "complete") {
       let result = confirm(this.fullHistWarning);
       if(!result){
-        this.inputDomElement.prop("checked", !this.checked);
+        $(`div[data-id=${this.id}][data-switchtype=${this.attributeState}].permission-switch`).find('input').prop("checked", true);
+        //this.inputDomElement.prop("checked", true);
         return;
       }
     }
+    COPO.permissions.iconToggle(this.switchtype, this.id);
     this.permission[this.attribute] = this.nextState();
     $.ajax({
       url: `/users/${this.user}/devices/${this.permission['device_id']}/permissions/${this.id}`,
@@ -48,14 +48,8 @@ class LocalSwitch extends PermissionSwitch {
   }
 
   nextState() {
-    if(this.attributeState === "disallowed") {
-      return "last_only"
-    } else if(this.switchtype === "disallowed") {
-      return "disallowed"
-    } else if(this.attributeState === "complete") {
-      return "last_only"
-    } else if(this.attributeState === "last_only") {
-      return "complete"
+    if(this.attribute === "privilege") {
+      return this.switchtype
     } else {
       return !this.attributeState
     }
@@ -70,7 +64,7 @@ class MasterSwitch extends PermissionSwitch {
   }
 
   toggleSwitch() {
-    if (this.switchtype === "last_only" && this.checked === true) {
+    if (this.switchtype === "complete"){
       let result = confirm(this.fullHistWarning);
       if(!result){
         this.inputDomElement.prop("checked", !this.checked);
@@ -101,9 +95,9 @@ class MasterSwitch extends PermissionSwitch {
     this.inputDomElement.prop("checked", NEW_MASTER_CHECKED_STATE)
 
     if (this.switchtype === "disallowed") {
-      $(`div[data-id=${this.id}][data-switchtype=last_only].master`).find('input').prop("checked", false);
-      const MASTERS = $(`div[data-id=${this.id}].disable.master`).find('input');
-      MASTERS.prop("disabled", NEW_MASTER_CHECKED_STATE);
+      //$(`div[data-id=${this.id}][data-switchtype=last_only].master`).find('input').prop("checked", false);
+      //const MASTERS = $(`div[data-id=${this.id}].disable.master`).find('input');
+      //MASTERS.prop("disabled", NEW_MASTER_CHECKED_STATE);
     }
   }
 }

--- a/app/assets/javascripts/devices/devices-index.es6
+++ b/app/assets/javascripts/devices/devices-index.es6
@@ -17,6 +17,12 @@ $(document).on('page:change', function() {
       }
     })
 
+    $('.cloakedButton').each((index, cloakedButton) => {
+      if($(cloakedButton).data('cloaked')){
+        $(cloakedButton).removeData('confirm').removeAttr('data-confirm')
+      }
+    })
+
     $('body').on('click', '.edit-button', function (e) {
       e.preventDefault();
       $(this).toggleClass('hide', true);

--- a/app/assets/javascripts/permissions.es6
+++ b/app/assets/javascripts/permissions.es6
@@ -4,39 +4,11 @@ window.COPO.permissions = {
     COPO.permissions.setMasters(page, user, permissions);
     COPO.permissions.masterChange(page, user, permissions);
     COPO.permissions.switchChange(page, user, permissions);
-    COPO.permissions.checkDisabled(user);
-    COPO.permissions.checkBypass(user);
   },
 
   switchesOff: function(){
     $(".permission-switch").off("change");
     $(".master").off("change");
-  },
-
-  checkDisabled: function(user){
-    $('[data-switchtype=disallowed].permission-switch').each(function(){
-      const P_SWITCH = new PermissionSwitch(user, $(this))
-      if (P_SWITCH.checked){
-        //P_SWITCH.changeDisableSwitches(true);
-      } else {
-        $('#accessIcon'+P_SWITCH.id).css('display', 'none');
-      }
-    });
-  },
-
-  checkBypass: function(user){
-    ['bypass_fogging', 'bypass_delay'].forEach(function(attribute){
-      $(`[data-switchtype=${attribute}]`).each(function(){
-        const P_SWITCH = new PermissionSwitch(user, $(this))
-        if (P_SWITCH.checked){
-          if (P_SWITCH.switchtype === 'bypass_fogging'){
-            $('#fogIcon'+P_SWITCH.id).css('display', 'none');
-          } else {
-            $('#delayIcon'+P_SWITCH.id).css('display', 'none');
-          }
-        }
-      });
-    })
   },
 
   setMasters: function(page, user, gonPermissions){
@@ -68,16 +40,4 @@ window.COPO.permissions = {
       M_SWITCH.setState();
     })
   },
-
-  iconToggle: function(switchtype, permissionId){
-    if (switchtype === 'bypass_fogging'){
-      $('#fogIcon'+permissionId).toggle();
-    } else if (switchtype === 'bypass_delay'){
-      $('#delayIcon'+permissionId).toggle();
-    } else if (switchtype === 'disallowed'){
-      $('#accessIcon'+permissionId).toggle();
-    } else if (switchtype === 'last_only' || switchtype === 'complete'){
-      $('#accessIcon'+permissionId).css('display', 'none');
-    } 
-  }
 };

--- a/app/assets/javascripts/permissions.es6
+++ b/app/assets/javascripts/permissions.es6
@@ -17,7 +17,7 @@ window.COPO.permissions = {
     $('[data-switchtype=disallowed].permission-switch').each(function(){
       const P_SWITCH = new PermissionSwitch(user, $(this))
       if (P_SWITCH.checked){
-        P_SWITCH.changeDisableSwitches(true);
+        //P_SWITCH.changeDisableSwitches(true);
       } else {
         $('#accessIcon'+P_SWITCH.id).css('display', 'none');
       }
@@ -76,6 +76,8 @@ window.COPO.permissions = {
       $('#delayIcon'+permissionId).toggle();
     } else if (switchtype === 'disallowed'){
       $('#accessIcon'+permissionId).toggle();
-    }
+    } else if (switchtype === 'last_only' || switchtype === 'complete'){
+      $('#accessIcon'+permissionId).css('display', 'none');
+    } 
   }
 };

--- a/app/assets/javascripts/permissionsTrigger.es6
+++ b/app/assets/javascripts/permissionsTrigger.es6
@@ -3,8 +3,8 @@ window.COPO.permissionsTrigger = {
   initTrigger: function(page){
     $('.permissions-trigger').leanModal()
     $('.permissions-trigger').on('click touchstart', function(){
-      const DEVICE_ID = this.dataset.device;
-      const $LIST = $(`.permissions[data-device=${DEVICE_ID}]`)
+      const DEVICE_ID = this.dataset.id;
+      const $LIST = $(`.permissions[data-id=${DEVICE_ID}]`)
       if($LIST.children().length===1) {
         const FROM = { from: page }
         $LIST.append('<div class="progress"><div class="indeterminate"></div></div>');

--- a/app/assets/javascripts/permissionsTrigger.es6
+++ b/app/assets/javascripts/permissionsTrigger.es6
@@ -3,11 +3,9 @@ window.COPO.permissionsTrigger = {
   initTrigger: function(page){
     $('.permissions-trigger').leanModal()
     $('.permissions-trigger').on('click touchstart', function(){
-      const device = this.dataset.device;
-      const $LIST = $(`.permissions[data-device=${device}]`)
-      // const $LIST = $(this.parentElement).find('.permissions')
+      const DEVICE_ID = this.dataset.device;
+      const $LIST = $(`.permissions[data-device=${DEVICE_ID}]`)
       if($LIST.children().length===1) {
-        const DEVICE_ID = page === 'devices' ? $LIST.data().device : $LIST.data().friend;
         const FROM = { from: page }
         $LIST.append('<div class="progress"><div class="indeterminate"></div></div>');
         $.get({

--- a/app/assets/javascripts/permissionsTrigger.es6
+++ b/app/assets/javascripts/permissionsTrigger.es6
@@ -3,7 +3,9 @@ window.COPO.permissionsTrigger = {
   initTrigger: function(page){
     $('.permissions-trigger').leanModal()
     $('.permissions-trigger').on('click touchstart', function(){
-      const $LIST = $(this.parentElement).find('.permissions')
+      const device = this.dataset.device;
+      const $LIST = $(`.permissions[data-device=${device}]`)
+      // const $LIST = $(this.parentElement).find('.permissions')
       if($LIST.children().length===1) {
         const DEVICE_ID = page === 'devices' ? $LIST.data().device : $LIST.data().friend;
         const FROM = { from: page }

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -6,6 +6,11 @@
   .editable {
     color: $dark-text-color;
   }
+
+  .device-name {
+    display: inline;
+  }
+  
   .linkbox {
     width: auto;
     height: inherit;

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -43,6 +43,11 @@
     color: rgba(0,0,0,0.2);
   }
 
+  .device-control {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
   .cloaked-icon {
     position: relative;
     &:after {

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -80,41 +80,8 @@
     margin-right: 1rem;
   }
 
-  .cloaked-icon {
-    position: relative;
-    &:after {
-      content:" ";
-      // these are relative to font based settings
-      height: 4px; // arbitary width of the strikethrough that visually matches
-      width: 24px; // matches font-size
-      border-top: white solid 2px;
-      background-color: #039be5; //needs to be solid. Matches how the icon renders on white
-      position: absolute;
-      top: 11px; //half font height but slightly higher to offset the visual illusion
-      left: 0;
-      transform: rotate(45deg);
-    }
-  }
-
   .cloaked-info {
     font-size: 14px;
-  }
-
-  .disabled-icon-dashed {
-    color: rgba(0,0,0,0.2);
-    position: relative;
-    &:after {
-      content:" ";
-      // these are relative to font based settings
-      height: 4px; // arbitary width of the strikethrough that visually matches
-      width: 24px; // matches font-size
-      border-top: white solid 2px;
-      background-color: #ccc; //needs to be solid. Matches how the icon renders on white
-      position: absolute;
-      top: 11px; //half font height but slightly higher to offset the visual illusion
-      left: 0;
-      transform: rotate(45deg);
-    }
   }
 
   #map-overlay {

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -1,10 +1,15 @@
 .c-devices.a-index {
   .center-map {
-    color: $primary-color-darker;
+    color: $primary-color;
     cursor: pointer;
   }
+
   .editable {
-    color: $dark-text-color;
+    color: $primary-color;
+  }
+
+  a {
+    color: $primary-color;
   }
 
   .inline-text {

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -38,6 +38,22 @@
     color: rgba(0,0,0,0.2);
   }
 
+  .cloaked-icon {
+    position: relative;
+    &:after {
+      content:" ";
+      // these are relative to font based settings
+      height: 4px; // arbitary width of the strikethrough that visually matches
+      width: 24px; // matches font-size
+      border-top: white solid 2px;
+      background-color: #039be5; //needs to be solid. Matches how the icon renders on white
+      position: absolute;
+      top: 11px; //half font height but slightly higher to offset the visual illusion
+      left: 0;
+      transform: rotate(45deg);
+    }
+  }
+
   .disabled-icon {
     color: rgba(0,0,0,0.2);
     position: relative;

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -39,7 +39,7 @@
     margin: 0.25rem 0 0 0;
   }
 
-  .disabled-icon-simple {
+  .disabled-icon {
     color: rgba(0,0,0,0.2);
   }
 
@@ -59,7 +59,7 @@
     }
   }
 
-  .disabled-icon {
+  .disabled-icon-dashed {
     color: rgba(0,0,0,0.2);
     position: relative;
     &:after {

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -34,6 +34,10 @@
     margin: 0.25rem 0 0 0;
   }
 
+  .disabled-icon-simple {
+    color: rgba(0,0,0,0.2);
+  }
+
   .disabled-icon {
     color: rgba(0,0,0,0.2);
     position: relative;

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -7,7 +7,7 @@
     color: $dark-text-color;
   }
 
-  .device-name {
+  .inline-text {
     display: inline;
   }
   
@@ -57,6 +57,10 @@
       left: 0;
       transform: rotate(45deg);
     }
+  }
+
+  .cloaked-info {
+    font-size: 14px;
   }
 
   .disabled-icon-dashed {

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -4,6 +4,27 @@
     cursor: pointer;
   }
 
+  .row {
+    margin-bottom: 5px;
+  }
+
+  .btn-flat i {
+    color: inherit;
+  }
+
+  .device-button {
+    background-color: $primary-color;
+    color: #ffffff !important;
+    width: 60%;
+  }
+
+  .device-toggle {
+    line-height: 36px;
+    text-transform: none !important;
+    margin-right: 0px !important;
+    color: #000000 !important;
+  }
+
   .editable {
     color: $primary-color-darker;
   }
@@ -17,8 +38,8 @@
     height: inherit;
     border: 1px solid darkgrey;
     border-radius: 2px;
-    font-size: 12px;
     margin: 2px;
+    line-height: 36px;
 
     &:focus {
       @extend .linkbox;

--- a/app/assets/stylesheets/devices-index.scss
+++ b/app/assets/stylesheets/devices-index.scss
@@ -1,15 +1,11 @@
 .c-devices.a-index {
   .center-map {
-    color: $primary-color;
+    color: $primary-color-darker;
     cursor: pointer;
   }
 
   .editable {
-    color: $primary-color;
-  }
-
-  a {
-    color: $primary-color;
+    color: $primary-color-darker;
   }
 
   .inline-text {
@@ -42,6 +38,16 @@
   .card-panel {
     padding: 5px;
     margin: 0.25rem 0 0 0;
+  }
+
+  .enabled-icon {
+    color: $primary-color-darker;
+  }
+
+  .modal {
+    .enabled-icon {
+      color: black;
+    }
   }
 
   .disabled-icon {

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
 
   def index
     devices = req_from_coposition_app? ? @user.devices : @user.devices.public_info
+    devices = devices.where(cloaked: false) unless current_user?(params[:user_id])
     render json: devices
   end
 
@@ -23,6 +24,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
 
   def show
     device = @user.devices.where(id: params[:id]).first
+    device = nil if device && device.cloaked? && !current_user?(params[:user_id])
     return unless device_exists? device
     device = device.public_info unless req_from_coposition_app? || @dev.configures_device?(device)
     render json: { data: device, config: configuration(device) }

--- a/app/controllers/api/v1/users/devices_controller.rb
+++ b/app/controllers/api/v1/users/devices_controller.rb
@@ -24,8 +24,7 @@ class Api::V1::Users::DevicesController < Api::ApiController
 
   def show
     device = @user.devices.where(id: params[:id]).first
-    device = nil if device && device.cloaked? && !current_user?(params[:user_id])
-    return unless device_exists? device
+    return unless device_exists? device && (!device.cloaked? || current_user?(params[:user_id]))
     device = device.public_info unless req_from_coposition_app? || @dev.configures_device?(device)
     render json: { data: device, config: configuration(device) }
   end

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -84,6 +84,10 @@ class Users::DevicesController < ApplicationController
   end
 
   def published?
-    redirect_to root_path, notice: 'Device is not shared' unless Device.find(params[:id]).published?
+    if Device.find(params[:id]).cloaked?
+      redirect_to root_path, notice: 'Could not find device'
+    else
+      redirect_to root_path, notice: 'Device is not shared' unless Device.find(params[:id]).published?
+    end
   end
 end

--- a/app/controllers/users/devices_controller.rb
+++ b/app/controllers/users/devices_controller.rb
@@ -84,10 +84,8 @@ class Users::DevicesController < ApplicationController
   end
 
   def published?
-    if Device.find(params[:id]).cloaked?
-      redirect_to root_path, notice: 'Could not find device'
-    else
-      redirect_to root_path, notice: 'Device is not shared' unless Device.find(params[:id]).published?
-    end
+    device = Device.find(params[:id])
+    return if device.published? && !device.cloaked?
+    redirect_to root_path, notice: 'Could not find shared device'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def fogged_icon(value)
     if value
-      '<i class="material-icons">cloud</i>'.html_safe
+      '<i class="material-icons enabled-icon">cloud</i>'.html_safe
     else
       '<i class="material-icons disabled-icon">cloud</i>'.html_safe
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def fogged_icon(value)
     if value
-      '<i class="material-icons">cloud_done</i>'.html_safe
+      '<i class="material-icons">cloud</i>'.html_safe
     else
       '<i class="material-icons disabled-icon">cloud</i>'.html_safe
     end

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -47,6 +47,15 @@ module DevicesHelper
     output
   end
 
+  def devices_cloaked_icon(value)
+    if device.cloaked?
+      '<i class="material-icons">do_not_disturb</i>'.html_safe
+    else
+      '<i class="material-icons disabled-icon-simple ">do_not_disturb</i>'.html_safe
+    end
+  end
+
+
   def devices_config_rows(config)
     return '<tr><td><i>No additional config</i></td></tr>'.html_safe unless config.custom.present?
     output = config.custom.map do |key, value|

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -55,6 +55,11 @@ module DevicesHelper
     end
   end
 
+  def devices_cloaked_info(value)
+    if value
+      "<div class='inline grey-text'>This device is cloaked. No friends or apps can see it or its check-ins.</div>".html_safe 
+    end
+  end
 
   def devices_config_rows(config)
     return '<tr><td><i>No additional config</i></td></tr>'.html_safe unless config.custom.present?

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -17,7 +17,7 @@ module DevicesHelper
 
   def devices_delay_icon(value)
     if value
-      '<i class="material-icons">timer</i>'.html_safe
+      '<i class="material-icons enabled-icon">timer</i>'.html_safe
     else
       '<i class="material-icons disabled-icon">timer</i>'.html_safe
     end
@@ -25,7 +25,7 @@ module DevicesHelper
 
   def devices_shared_icon(device)
     if device.published?
-      '<i class="material-icons">public</i>'.html_safe
+      '<i class="material-icons enabled-icon">public</i>'.html_safe
     else
       '<i class="material-icons disabled-icon">public</i>'.html_safe
     end
@@ -49,7 +49,7 @@ module DevicesHelper
 
   def devices_cloaked_icon(value)
     if value
-      '<i class="material-icons">visibility_off</i>'.html_safe
+      '<i class="material-icons enabled-icon">visibility_off</i>'.html_safe
     else
       '<i class="material-icons disabled-icon">visibility_off</i>'.html_safe
     end

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -8,10 +8,10 @@ module DevicesHelper
       last_checkin = device.checkins.first
       postcode = last_checkin.postal_code
       last_checkin.address = last_checkin.address.gsub(' ' + postcode, '') if postcode
-      "<p>Last reported in #{last_checkin.address} on #{humanize_date_and_time(last_checkin.created_at)}
-      <i data-device='#{device.id}' class='center-map material-icons'>my_location</i></p>".html_safe
+      "Last reported in #{last_checkin.address} on #{humanize_date_and_time(last_checkin.created_at)}
+      <i data-device='#{device.id}' class='center-map material-icons'>my_location</i>".html_safe
     else
-      '<p>No Checkins found</p>'.html_safe
+      'No Checkins found'.html_safe
     end
   end
 

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -25,9 +25,9 @@ module DevicesHelper
 
   def devices_shared_icon(device)
     if device.published?
-      '<i class="material-icons">visibility</i>'.html_safe
+      '<i class="material-icons">public</i>'.html_safe
     else
-      '<i class="material-icons disabled-icon">visibility</i>'.html_safe
+      '<i class="material-icons disabled-icon">public</i>'.html_safe
     end
   end
 
@@ -48,10 +48,10 @@ module DevicesHelper
   end
 
   def devices_cloaked_icon(value)
-    if device.cloaked?
-      '<i class="material-icons">do_not_disturb</i>'.html_safe
+    if value
+      '<i class="material-icons">visibility_off</i>'.html_safe
     else
-      '<i class="material-icons disabled-icon-simple ">do_not_disturb</i>'.html_safe
+      '<i class="material-icons disabled-icon-simple">visibility_off</i>'.html_safe
     end
   end
 

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -57,7 +57,7 @@ module DevicesHelper
 
   def devices_cloaked_info(value)
     if value
-      "<div class='inline grey-text'>This device is cloaked. No friends or apps can see it or its check-ins.</div>".html_safe 
+      "<div class='inline-text cloaked-info grey-text'>This device is cloaked. No friends or apps can see this device or its check-ins.</div>".html_safe 
     end
   end
 

--- a/app/helpers/devices_helper.rb
+++ b/app/helpers/devices_helper.rb
@@ -51,7 +51,7 @@ module DevicesHelper
     if value
       '<i class="material-icons">visibility_off</i>'.html_safe
     else
-      '<i class="material-icons disabled-icon-simple">visibility_off</i>'.html_safe
+      '<i class="material-icons disabled-icon">visibility_off</i>'.html_safe
     end
   end
 

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -36,8 +36,4 @@ module PermissionsHelper
       end
     end
   end
-
-  def permissions_for_all(permissionable)
-    '' unless permissionable.class == Permission
-  end
 end

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -38,6 +38,6 @@ module PermissionsHelper
   end
 
   def permissions_for_all(permissionable)
-    ' for all' unless permissionable.class == Permission
+    '' unless permissionable.class == Permission
   end
 end

--- a/app/helpers/permissions_helper.rb
+++ b/app/helpers/permissions_helper.rb
@@ -20,12 +20,16 @@ module PermissionsHelper
   end
 
   def permissions_label_id(permissionable, switchtype)
-    "#{permissionable.id}-#{switchtype}" if permissionable.class == Permission
+    if permissionable.class == Permission
+      "#{permissionable.id}_#{switchtype}"
+    else
+      "master_#{permissionable.id}_#{switchtype}"
+    end
   end
 
   def permissions_check_box_value(permissionable, type)
     if permissionable.class == Permission
-      if %w(disallowed complete).include? type
+      if %w(disallowed last_only complete).include? type
         permissionable.privilege == type
       else
         permissionable[type]

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -58,11 +58,12 @@ class Device < ApplicationRecord
   end
 
   def permitted_history_for(permissible)
+    return Checkin.none if cloaked
     resolve_privilege(delayed_checkins_for(permissible), permissible)
   end
 
   def resolve_privilege(unresolved_checkins, permissible)
-    return Checkin.none if privilege_for(permissible) == 'disallowed' || cloaked
+    return Checkin.none if privilege_for(permissible) == 'disallowed'
     return unresolved_checkins if unresolved_checkins.empty?
     if privilege_for(permissible) == 'last_only'
       unresolved_checkins.where(id: unresolved_checkins.first.id)

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -62,7 +62,7 @@ class Device < ApplicationRecord
   end
 
   def resolve_privilege(unresolved_checkins, permissible)
-    return Checkin.none if privilege_for(permissible) == 'disallowed'
+    return Checkin.none if privilege_for(permissible) == 'disallowed' || cloaked
     return unresolved_checkins if unresolved_checkins.empty?
     if privilege_for(permissible) == 'last_only'
       unresolved_checkins.where(id: unresolved_checkins.first.id)

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -16,7 +16,7 @@ module Users
     end
 
     def show
-      @devices = @friend.devices.ordered_by_checkins.paginate(page: @params[:page], per_page: 5)
+      @devices = @friend.devices.where(cloaked: false).ordered_by_checkins.paginate(page: @params[:page], per_page: 5)
     end
 
     def show_device

--- a/app/presenters/users/friends_presenter.rb
+++ b/app/presenters/users/friends_presenter.rb
@@ -20,7 +20,7 @@ module Users
     end
 
     def show_device
-      @device = @friend.devices.find(@params[:device_id])
+      @device = @friend.devices.where(cloaked: false).find(@params[:device_id])
     end
 
     def index_gon

--- a/app/services/users/devices/update_device.rb
+++ b/app/services/users/devices/update_device.rb
@@ -15,7 +15,7 @@ module Users::Devices
       elsif @params[:name]
         @device.update(name: @params[:name])
       elsif @params[:cloaked]
-        @device.update(cloaked: @params[:cloaked])
+        @device.update(cloaked: !@device.cloaked)
       else
         @device.switch_fog
       end
@@ -28,7 +28,7 @@ module Users::Devices
       elsif @params[:published]
         "Location sharing is #{boolean_to_state(@device.published)}."
       elsif @params[:cloaked]
-        "Device cloaking is #{boolean_to_state(@device.fogged)}."
+        "Device cloaking is #{boolean_to_state(@device.cloaked)}."
       elsif !@params[:name]
         "Location fogging is #{boolean_to_state(@device.fogged)}."
       end

--- a/app/services/users/devices/update_device.rb
+++ b/app/services/users/devices/update_device.rb
@@ -14,6 +14,8 @@ module Users::Devices
         @device.update(published: !@device.published)
       elsif @params[:name]
         @device.update(name: @params[:name])
+      elsif @params[:cloaked]
+        @device.update(cloaked: @params[:cloaked])
       else
         @device.switch_fog
       end
@@ -25,6 +27,8 @@ module Users::Devices
         @device.humanize_delay
       elsif @params[:published]
         "Location sharing is #{boolean_to_state(@device.published)}."
+      elsif @params[:cloaked]
+        "Device cloaking is #{boolean_to_state(@device.fogged)}."
       elsif !@params[:name]
         "Location fogging is #{boolean_to_state(@device.fogged)}."
       end

--- a/app/views/users/approvals/_approved.html.erb
+++ b/app/views/users/approvals/_approved.html.erb
@@ -29,13 +29,13 @@
 
         <div class="col s4">
           <% if current_user.devices.exists? %>
-            <a class="waves-effect waves-light btn-flat permissions-trigger right" href="#perm<%=approvable.id%>" data-device=<%=approvable.id%>>
+            <a class="waves-effect waves-light btn-flat permissions-trigger right" href="#perm<%=approvable.id%>" data-id=<%=approvable.id%>>
               <i class="material-icons right">lock</i>Permissions
             </a>
             <div id="perm<%=approvable.id%>" class="modal">
               <div class="modal-content">
                 <h4 class="modal-content">Permissions controls for <%=approvals_approvable_name(approvable)%></h4>
-                <ul class="permissions collection" data-device=<%=approvable.id%>>
+                <ul class="permissions collection" data-id=<%=approvable.id%>>
                   <li class="collection-item row valign-wrapper  master-permissions">
                     <div class='valign col s6'>
                       <h5>Update all permissions</h5>

--- a/app/views/users/approvals/_approved.html.erb
+++ b/app/views/users/approvals/_approved.html.erb
@@ -29,11 +29,13 @@
 
         <div class="col s4">
           <% if current_user.devices.exists? %>
-            <a class="waves-effect waves-light btn-flat permissions-trigger right" href="#perm<%=approvable.id%>"><i class="material-icons right">lock</i>Permissions</a>
+            <a class="waves-effect waves-light btn-flat permissions-trigger right" href="#perm<%=approvable.id%>" data-device=<%=approvable.id%>>
+              <i class="material-icons right">lock</i>Permissions
+            </a>
             <div id="perm<%=approvable.id%>" class="modal">
               <div class="modal-content">
                 <h4 class="modal-content">Permissions controls for <%=approvals_approvable_name(approvable)%></h4>
-                <ul class="permissions collection" data-friend=<%=approvable.id%>>
+                <ul class="permissions collection" data-device=<%=approvable.id%>>
                   <li class="collection-item row valign-wrapper  master-permissions">
                     <div class='valign col s6'>
                       <h5>Update all permissions</h5>

--- a/app/views/users/approvals/_approved.html.erb
+++ b/app/views/users/approvals/_approved.html.erb
@@ -35,8 +35,8 @@
                 <h4 class="modal-content">Permissions controls for <%=approvals_approvable_name(approvable)%></h4>
                 <ul class="permissions collection" data-friend=<%=approvable.id%>>
                   <li class="collection-item row valign-wrapper  master-permissions">
-                    <div class='valign col s7'>
-                      <h5>Master permissions</h5>
+                    <div class='valign col s6'>
+                      <h5>Update all permissions</h5>
                     </div>
                     <%= render partial: "users/permissions/controls", object: approvable, as: 'permissionable' %>
                   </li>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -45,6 +45,8 @@
 
     <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'left tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
 
+    <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id), { method: :put, id:"cloakButton#{device.id}", remote: true, class: 'left tooltipped cloakButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
+
     <a class="modal-trigger left tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>"><i class="material-icons">file_download</i></a>
     <div id="download<%=device.id%>" class="modal download-modal">
       <div class="modal-content">

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -2,67 +2,72 @@
 
   <div class="col s12">
 
+    <span class="valign-wrapper">
+      <h4 class="device-name">
+        <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
+      </h4>
+      <span class="right-align">
+        <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'right tooltipped', data: { tooltip: 'Additional device information' } do %>
+          <i class='material-icons grey-text valign'>perm_device_info</i>
+        <% end %>
 
-    <h4>
-      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
-    </h4>
-      <%= devices_last_checkin(device) %>
+        <% if device.developers.exists? || device.permitted_users.exists? %>
+          <a class="right permissions-trigger tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>"><i class="material-icons grey-text">lock</i></a>
 
-    <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'left tooltipped', data: { tooltip: 'Additional device information' } do %>
-      <i class='material-icons valign'>perm_device_info</i>
-    <% end %>
+          <div id="perm<%=device.id%>" class="modal">
+            <div class="modal-content">
+              <h4>Permission control for <%=device.name%>
+              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
+              <ul class="permissions collection" data-device=<%=device.id%>>
+                <li class="collection-item row valign-wrapper  master-permissions">
+                  <div class='valign col s6' id="<%=device.id%>-status">
+                    <h5>Master permissions <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %></h5>
+                    This device is <%= device.fogged ? 'fogged' : 'not fogged' %> and is
+                    <%= device.delayed ? "delayed by #{device.delayed} minutes" : 'not delayed' %>.
+                  </div>
+                  <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
+                </li>
 
-    <% if device.developers.exists? || device.permitted_users.exists? %>
-      <a class="permissions-trigger left tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>"><i class="material-icons">lock</i></a>
+              </ul>
+            </div>
+          </div>
+        <% end %>
 
-      <div id="perm<%=device.id%>" class="modal">
+        <a class="modal-trigger right tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>"><i class="grey-text material-icons">file_download</i></a>
+        <div id="download<%=device.id%>" class="modal download-modal">
+          <div class="modal-content">
+            <h4 class='center-align'>Choose download format</h4>
+            <div class='center-align'>
+              <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
+              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
+              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
+              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
+            </div>
+          </div>
+        </div>
+      </span>
+    </span>
+
+    <div>
+      <a class="modal-trigger left tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
+      <div id="delay<%=device.id%>" class="modal delay-modal">
         <div class="modal-content">
-          <h4>Permission control for <%=device.name%>
-          <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
-          <ul class="permissions collection" data-device=<%=device.id%>>
-            <li class="collection-item row valign-wrapper  master-permissions">
-              <div class='valign col s7' id="<%=device.id%>-status">
-                <h5>Master permissions <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %></h5>
-                This device is <%= device.fogged ? 'fogged' : 'not fogged' %> and is
-                <%= device.delayed ? "delayed by #{device.delayed} minutes" : 'not delayed' %>.
-              </div>
-              <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
-            </li>
-
-          </ul>
+          <h4>Delay Controls</h4>
+          <label>Set when new checkins will become visible to your data consumers</label>
+          <div class='delay-slider' data-device=<%=device.id%>></div>
         </div>
       </div>
-    <% end %>
 
-    <a class="modal-trigger left tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
-    <div id="delay<%=device.id%>" class="modal delay-modal">
-      <div class="modal-content">
-        <h4>Delay Controls</h4>
-        <label>Set when new checkins will become visible to your data consumers</label>
-        <div class='delay-slider' data-device=<%=device.id%>></div>
+      <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'left tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
+
+      <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'left tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
+      
+      <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'left tooltipped', data: { published: device.published?, tooltip:'Device sharing' } })%>
+      <div class="valign-wrapper" id="sharedLink<%= device.id %>">
+        <%= devices_shared_link(device) if device.published %>
       </div>
     </div>
-
-    <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'left tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
-
-    <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'left tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
-
-    <a class="modal-trigger left tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>"><i class="material-icons">file_download</i></a>
-    <div id="download<%=device.id%>" class="modal download-modal">
-      <div class="modal-content">
-        <h4 class='center-align'>Choose download format</h4>
-        <div class='center-align'>
-          <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
-          <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
-          <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
-          <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
-        </div>
-      </div>
-    </div>
-    
-    <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'left tooltipped', data: { published: device.published?, tooltip:'Device sharing' } })%>
-    <div class="valign-wrapper" id="sharedLink<%= device.id %>">
-      <%= devices_shared_link(device) if device.published %>
-    </div>
+    <br/>
+    <%= devices_last_checkin(device) %>
   </div>
 </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -16,14 +16,12 @@
 
           <div id="perm<%=device.id%>" class="modal">
             <div class="modal-content">
-                <h4><%=device.name%> permissions
+                <h4><%=device.name%> permissions <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %>
                 <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
               <ul class="permissions collection" data-device=<%=device.id%>>
                 <li class="collection-item row valign-wrapper  master-permissions">
                   <div class='valign col s6' id="<%=device.id%>-status">
-                    <h5>Master permissions <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %></h5>
-                    This device is <%= device.fogged ? 'fogged' : 'not fogged' %> and is
-                    <%= device.delayed ? "delayed by #{device.delayed} minutes" : 'not delayed' %>.
+                    <h5>Update all permissions </h5>
                   </div>
                   <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
                 </li>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -6,12 +6,12 @@
       <h4 class="inline-text">
         <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
-      <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped', data: { tooltip: 'Additional device information' } do %>
-        <div class="grey-text valign-wrapper">&nbsp; Additional Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>
+      <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped device-control', data: { tooltip: 'Additional device information' } do %>
+        <div class="grey-text valign-wrapper">&nbsp; Device Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>
       <% end %>
 
       <% if device.developers.exists? || device.permitted_users.exists? %>
-        <a class="permissions-trigger tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>">
+        <a class="permissions-trigger device-control tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>">
           <div class="grey-text valign-wrapper">&nbsp; Permissions &nbsp;<i class="material-icons grey-text">lock</i></div>
         </a>
 
@@ -35,7 +35,7 @@
           </div>
         </div>
       <% end %>
-      <a class="modal-trigger right tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>">
+      <a class="modal-trigger device-control tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>">
         <div class="grey-text valign-wrapper">&nbsp; Download check-ins &nbsp;<i class="grey-text material-icons">file_download</i></div>
       </a>
 
@@ -53,7 +53,7 @@
     </div>
 
     <div class='valign-wrapper'>
-      <div class="grey-text valign-wrapper">&nbsp; Delay &nbsp;
+      <div class="grey-text device-control valign-wrapper">&nbsp; Delay &nbsp;
         <a class="modal-trigger tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
       </div>
       <div id="delay<%=device.id%>" class="modal delay-modal">
@@ -63,13 +63,13 @@
           <div class='delay-slider' data-device=<%=device.id%>></div>
         </div>
       </div>
-      <div class="grey-text valign-wrapper">&nbsp; Fogging &nbsp;
+      <div class="grey-text device-control valign-wrapper">&nbsp; Fogging &nbsp;
         <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
       </div>
-      <div class="grey-text valign-wrapper">&nbsp; Cloaking &nbsp;
+      <div class="grey-text device-control valign-wrapper">&nbsp; Cloaking &nbsp;
         <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
       </div>
-      <div class="grey-text valign-wrapper">&nbsp; Sharing &nbsp;
+      <div class="grey-text device-control valign-wrapper">&nbsp; Sharing &nbsp;
         <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'tooltipped', data: { published: device.published?, tooltip:'Sharing' } })%>
       </div>
       <div class="valign-wrapper" id="sharedLink<%= device.id %>">

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -6,48 +6,52 @@
       <h4 class="device-name">
         <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
-      <div>
-        <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'right tooltipped', data: { tooltip: 'Additional device information' } do %>
-          <i class='material-icons grey-text valign'>perm_device_info</i>
-        <% end %>
+      <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped', data: { tooltip: 'Additional device information' } do %>
+        <div class="grey-text valign-wrapper">&nbsp; Additional Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>
+      <% end %>
 
-        <% if device.developers.exists? || device.permitted_users.exists? %>
-          <a class="right permissions-trigger tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>"><i class="material-icons grey-text">lock</i></a>
+      <% if device.developers.exists? || device.permitted_users.exists? %>
+        <a class="permissions-trigger tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>">
+          <div class="grey-text valign-wrapper">&nbsp; Permissions &nbsp;<i class="material-icons grey-text">lock</i></div>
+        </a>
 
-          <div id="perm<%=device.id%>" class="modal">
-            <div class="modal-content">
-                <h4 id='<%=device.id%>-status'><%=device.name%> permissions 
-                <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
-                <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
-              <ul class="permissions collection" data-device=<%=device.id%>>
-                <li class="collection-item row valign-wrapper  master-permissions">
-                  <div class='valign col s6'>
-                    <h5>Update all permissions </h5>
-                  </div>
-                  <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
-                </li>
-              </ul>
-            </div>
-          </div>
-        <% end %>
-
-        <a class="modal-trigger right tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>"><i class="grey-text material-icons">file_download</i></a>
-        <div id="download<%=device.id%>" class="modal download-modal">
+        <div id="perm<%=device.id%>" class="modal">
           <div class="modal-content">
-            <h4 class='center-align'>Choose download format</h4>
-            <div class='center-align'>
-              <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
-              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
-              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
-              <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
-            </div>
+              <h4 id='<%=device.id%>-status'><%=device.name%> permissions 
+              <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
+              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
+            <ul class="permissions collection" data-device=<%=device.id%>>
+              <li class="collection-item row valign-wrapper  master-permissions">
+                <div class='valign col s6'>
+                  <h5>Update all permissions </h5>
+                </div>
+                <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
+              </li>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+      <a class="modal-trigger right tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>">
+        <div class="grey-text valign-wrapper">&nbsp; Download check-ins &nbsp;<i class="grey-text material-icons">file_download</i></div>
+      </a>
+
+      <div id="download<%=device.id%>" class="modal download-modal">
+        <div class="modal-content">
+          <h4 class='center-align'>Choose download format</h4>
+          <div class='center-align'>
+            <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
+            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
+            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
+            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
           </div>
         </div>
       </div>
     </div>
 
     <div class='valign-wrapper'>
-      <a class="modal-trigger left tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
+      <div class="grey-text valign-wrapper">&nbsp; Delay &nbsp;
+        <a class="modal-trigger tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
+      </div>
       <div id="delay<%=device.id%>" class="modal delay-modal">
         <div class="modal-content">
           <h4>Delay Controls</h4>
@@ -55,12 +59,15 @@
           <div class='delay-slider' data-device=<%=device.id%>></div>
         </div>
       </div>
-
-      <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'left tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
-
-      <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'left tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
-      
-      <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'left tooltipped', data: { published: device.published?, tooltip:'Sharing' } })%>
+      <div class="grey-text valign-wrapper">&nbsp; Fogging &nbsp;
+        <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
+      </div>
+      <div class="grey-text valign-wrapper">&nbsp; Cloaking &nbsp;
+        <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
+      </div>
+      <div class="grey-text valign-wrapper">&nbsp; Sharing &nbsp;
+        <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'tooltipped', data: { published: device.published?, tooltip:'Sharing' } })%>
+      </div>
       <div class="valign-wrapper" id="sharedLink<%= device.id %>">
         <%= devices_shared_link(device) if device.published %>
       </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -16,12 +16,12 @@
 
           <div id="perm<%=device.id%>" class="modal">
             <div class="modal-content">
-                <h4><%=device.name%> permissions 
+                <h4 id='<%=device.id%>-status'><%=device.name%> permissions 
                 <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
                 <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
               <ul class="permissions collection" data-device=<%=device.id%>>
                 <li class="collection-item row valign-wrapper  master-permissions">
-                  <div class='valign col s6' id="<%=device.id%>-status">
+                  <div class='valign col s6'>
                     <h5>Update all permissions </h5>
                   </div>
                   <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
@@ -60,7 +60,7 @@
 
       <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'left tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
       
-      <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'left tooltipped', data: { published: device.published?, tooltip:'Device sharing' } })%>
+      <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'left tooltipped', data: { published: device.published?, tooltip:'Sharing' } })%>
       <div class="valign-wrapper" id="sharedLink<%= device.id %>">
         <%= devices_shared_link(device) if device.published %>
       </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -3,7 +3,7 @@
   <div class="col s12">
 
     <div class="valign-wrapper">
-      <h4 class="device-name">
+      <h4 class="inline-text">
         <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
       <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped', data: { tooltip: 'Additional device information' } do %>
@@ -18,7 +18,7 @@
         <div id="perm<%=device.id%>" class="modal">
           <div class="modal-content">
             <div>
-              <h4 class="device-name" id='<%=device.id%>-status'><%=device.name%> 
+              <h4 class="inline-text" id='<%=device.id%>-status'><%=device.name%> 
                 <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
               </h4>
               <%= devices_cloaked_info(device.cloaked) %>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -6,6 +6,8 @@
       <h4 class="inline-text">
         <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
+    </div>
+    <div class="valign-wrapper">
       <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped device-control', data: { tooltip: 'Additional device information' } do %>
         <div class="grey-text valign-wrapper">&nbsp; Device Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>
       <% end %>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -4,7 +4,7 @@
 
     <div class="valign-wrapper">
       <h4 class="inline-text">
-        <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
+        <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
       <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped device-control', data: { tooltip: 'Additional device information' } do %>
         <div class="grey-text valign-wrapper">&nbsp; Device Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -1,8 +1,7 @@
-
 <div class="card">
   <div class="card-content">
     <span class="card-title">
-      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
+      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i></a>
     </span>
     <div class="card-action">
       <div class="row">
@@ -13,12 +12,12 @@
             <% end %>
           </div>
           <div class="col s3">
-            <%= link_to user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'device-toggle fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged? } } do %>
-              <%=fogged_icon(device.fogged)%>Fogging
+            <%= link_to user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'device-toggle fogButton valign-wrapper', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged? } } do %>
+              <%=fogged_icon(device.fogged)%>&nbsp;Fogging
             <% end %>
           </div>
           <div class="col s3">
-            <a class="modal-trigger device-toggle" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%>Delay</a>
+            <a class="modal-trigger valign-wrapper device-toggle" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%>&nbsp;Delay</a>
           </div>
         </div>
       </div>
@@ -30,13 +29,13 @@
             </a>
           </div>
           <div class="col s3">
-            <%= link_to user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'tooltipped device-toggle cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } } do %>
-              <%=devices_cloaked_icon(device.cloaked)%>Cloaking
+            <%= link_to user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'device-toggle valign-wrapper cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked? } } do %>
+              <%=devices_cloaked_icon(device.cloaked)%>&nbsp;Cloaking
             <% end %>
           </div>
           <div class="col s3">
-            <%= link_to user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'device-toggle tooltipped', data: { published: device.published?, tooltip:'Sharing' } } do %>
-              <%=devices_shared_icon(device)%>Sharing
+            <%= link_to user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'device-toggle valign-wrapper', data: { published: device.published? } } do %>
+              <%=devices_shared_icon(device)%>&nbsp;Sharing
             <% end %>
           </div>
         </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -25,7 +25,6 @@
                   </div>
                   <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
                 </li>
-
               </ul>
             </div>
           </div>
@@ -46,7 +45,7 @@
       </div>
     </div>
 
-    <div>
+    <div class='valign-wrapper'>
       <a class="modal-trigger left tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
       <div id="delay<%=device.id%>" class="modal delay-modal">
         <div class="modal-content">
@@ -65,7 +64,6 @@
         <%= devices_shared_link(device) if device.published %>
       </div>
     </div>
-    <br/>
     <%= devices_last_checkin(device) %>
   </div>
 </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -1,83 +1,101 @@
-<div class="card-panel row">
 
-  <div class="col s12">
+<div class="card">
+  <div class="card-content">
+    <span class="card-title">
+      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
+    </span>
+    <div class="card-action">
+      <div class="row">
+        <div class="col s12">
+          <div class="col s6">
+            <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'btn-flat device-button' do %>
+              <i class="material-icons right">perm_device_info</i>Device info
+            <% end %>
+          </div>
+          <div class="col s3">
+            <%= link_to user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'device-toggle fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged? } } do %>
+              <%=fogged_icon(device.fogged)%>Fogging
+            <% end %>
+          </div>
+          <div class="col s3">
+            <a class="modal-trigger device-toggle" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%>Delay</a>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col s12">
+          <div class="col s6">
+            <a class="permissions-trigger btn-flat device-button" href="#perm<%=device.id%>" data-device=<%=device.id%>>
+              <i class="material-icons right">lock</i>Permissions</a>
+            </a>
+          </div>
+          <div class="col s3">
+            <%= link_to user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'tooltipped device-toggle cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } } do %>
+              <%=devices_cloaked_icon(device.cloaked)%>Cloaking
+            <% end %>
+          </div>
+          <div class="col s3">
+            <%= link_to user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'device-toggle tooltipped', data: { published: device.published?, tooltip:'Sharing' } } do %>
+              <%=devices_shared_icon(device)%>Sharing
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col s12">
+          <div class="col s6">
+            <a class="modal-trigger btn-flat device-button" id='downloadButton<%=device.id%>' href="#download<%=device.id%>">
+              <i class="material-icons right">file_download</i>Download check-ins</a>
+            </a>
+          </div>
+          <div class="col s6 valign-wrapper" id="sharedLink<%= device.id %>">
+            <%= devices_shared_link(device) if device.published %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card-action">
+      <p><%= devices_last_checkin(device) %><p>
+    </div>
+  </div>
+</div>
 
-    <div class="valign-wrapper">
-      <h4 class="inline-text">
-        <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
+<div id="perm<%=device.id%>" class="modal">
+  <div class="modal-content">
+    <div>
+      <h4 class="inline-text" id='<%=device.id%>-status'><%=device.name%> 
+        <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
       </h4>
+      <%= devices_cloaked_info(device.cloaked) %>
+      <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a>
     </div>
-    <div class="valign-wrapper">
-      <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'tooltipped device-control', data: { tooltip: 'Additional device information' } do %>
-        <div class="grey-text valign-wrapper">&nbsp; Device Info &nbsp;<i class='material-icons grey-text'>perm_device_info</i></div>
-      <% end %>
-
-      <% if device.developers.exists? || device.permitted_users.exists? %>
-        <a class="permissions-trigger device-control tooltipped" data-tooltip='Detailed Permissions' href="#perm<%=device.id%>">
-          <div class="grey-text valign-wrapper">&nbsp; Permissions &nbsp;<i class="material-icons grey-text">lock</i></div>
-        </a>
-
-        <div id="perm<%=device.id%>" class="modal">
-          <div class="modal-content">
-            <div>
-              <h4 class="inline-text" id='<%=device.id%>-status'><%=device.name%> 
-                <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
-              </h4>
-              <%= devices_cloaked_info(device.cloaked) %>
-              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a>
-            </div>
-            <ul class="permissions collection" data-device=<%=device.id%>>
-              <li class="collection-item row valign-wrapper  master-permissions">
-                <div class='valign col s6'>
-                  <h5>Update all permissions </h5>
-                </div>
-                <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
-              </li>
-            </ul>
-          </div>
+    <ul class="permissions collection" data-device=<%=device.id%>>
+      <li class="collection-item row valign-wrapper  master-permissions">
+        <div class='valign col s6'>
+          <h5>Update all permissions </h5>
         </div>
-      <% end %>
-      <a class="modal-trigger device-control tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>">
-        <div class="grey-text valign-wrapper">&nbsp; Download check-ins &nbsp;<i class="grey-text material-icons">file_download</i></div>
-      </a>
+        <%= render partial: "users/permissions/controls", object: device, as: 'permissionable' %>
+      </li>
+    </ul>
+  </div>
+</div>
 
-      <div id="download<%=device.id%>" class="modal download-modal">
-        <div class="modal-content">
-          <h4 class='center-align'>Choose download format</h4>
-          <div class='center-align'>
-            <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
-            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
-            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
-            <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
-          </div>
-        </div>
-      </div>
+<div id="download<%=device.id%>" class="modal download-modal">
+  <div class="modal-content">
+    <h4 class='center-align'>Choose download format</h4>
+    <div class='center-align'>
+      <label>Download all the check-ins on this device in one of the following formats:</label></br></br>
+      <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.csv?download=csv">csv</a></br></br>
+      <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.gpx?download=gpx">gpx (route)</a></br></br>
+      <a class="btn" href="<%= user_device_path(current_user.url_id, device) %>.geojson?download=geojson">geojson</a>
     </div>
+  </div>
+</div>
 
-    <div class='valign-wrapper'>
-      <div class="grey-text device-control valign-wrapper">&nbsp; Delay &nbsp;
-        <a class="modal-trigger tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>
-      </div>
-      <div id="delay<%=device.id%>" class="modal delay-modal">
-        <div class="modal-content">
-          <h4>Delay Controls</h4>
-          <label>Set when new checkins will become visible to your data consumers</label>
-          <div class='delay-slider' data-device=<%=device.id%>></div>
-        </div>
-      </div>
-      <div class="grey-text device-control valign-wrapper">&nbsp; Fogging &nbsp;
-        <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
-      </div>
-      <div class="grey-text device-control valign-wrapper">&nbsp; Cloaking &nbsp;
-        <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
-      </div>
-      <div class="grey-text device-control valign-wrapper">&nbsp; Sharing &nbsp;
-        <%= link_to(devices_shared_icon(device), user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'tooltipped', data: { published: device.published?, tooltip:'Sharing' } })%>
-      </div>
-      <div class="valign-wrapper" id="sharedLink<%= device.id %>">
-        <%= devices_shared_link(device) if device.published %>
-      </div>
-    </div>
-    <%= devices_last_checkin(device) %>
+<div id="delay<%=device.id%>" class="modal delay-modal">
+  <div class="modal-content">
+    <h4>Delay Controls</h4>
+    <label>Set when new checkins will become visible to your data consumers</label>
+    <div class='delay-slider' data-device=<%=device.id%>></div>
   </div>
 </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -1,8 +1,10 @@
 <div class="card">
   <div class="card-content">
-    <span class="card-title">
-      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i></a>
-    </span>
+    <div class="card-title">
+      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>">
+        <span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;
+      </a>
+    </div>
     <div class="card-action">
       <div class="row">
         <div class="col s12">

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -2,11 +2,11 @@
 
   <div class="col s12">
 
-    <span class="valign-wrapper">
+    <div class="valign-wrapper">
       <h4 class="device-name">
         <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i>&nbsp;</a>
       </h4>
-      <span class="right-align">
+      <div>
         <%= link_to info_user_device_path(current_user.url_id, device.id), class: 'right tooltipped', data: { tooltip: 'Additional device information' } do %>
           <i class='material-icons grey-text valign'>perm_device_info</i>
         <% end %>
@@ -16,8 +16,8 @@
 
           <div id="perm<%=device.id%>" class="modal">
             <div class="modal-content">
-              <h4>Permission control for <%=device.name%>
-              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
+                <h4><%=device.name%> permissions
+                <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
               <ul class="permissions collection" data-device=<%=device.id%>>
                 <li class="collection-item row valign-wrapper  master-permissions">
                   <div class='valign col s6' id="<%=device.id%>-status">
@@ -45,8 +45,8 @@
             </div>
           </div>
         </div>
-      </span>
-    </span>
+      </div>
+    </div>
 
     <div>
       <a class="modal-trigger left tooltipped" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%></a>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -17,7 +17,7 @@
 
         <div id="perm<%=device.id%>" class="modal">
           <div class="modal-content">
-              <h4 id='<%=device.id%>-status'><%=device.name%> permissions 
+              <h4 id='<%=device.id%>-status'><%=device.name%> 
               <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
               <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
             <ul class="permissions collection" data-device=<%=device.id%>>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -45,7 +45,7 @@
 
     <%= link_to(fogged_icon(device.fogged), user_device_path(current_user.url_id, device.id), { method: :put, id:"fogButton#{device.id}", remote: true, class: 'left tooltipped fogButton', data: { confirm: "Are you sure? Turning fogging off will allow you friends/apps to see your precise location", fogged: device.fogged?, tooltip:'Fogging' } })%>
 
-    <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id), { method: :put, id:"cloakButton#{device.id}", remote: true, class: 'left tooltipped cloakButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
+    <%= link_to(devices_cloaked_icon(device.cloaked), user_device_path(current_user.url_id, device.id, cloaked: device.cloaked), { method: :put, id:"cloakedButton#{device.id}", remote: true, class: 'left tooltipped cloakedButton', data: { confirm: "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends", cloaked: device.cloaked?, tooltip:'Cloaking' } })%>
 
     <a class="modal-trigger left tooltipped" id='downloadButton<%=device.id%>' data-tooltip='Download checkins' href="#download<%=device.id%>"><i class="material-icons">file_download</i></a>
     <div id="download<%=device.id%>" class="modal download-modal">

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
   <div class="card-content">
     <span class="card-title">
-      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable underlined"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i></a>
+      <a id="<%= device.name %>" href="<%= user_device_path(current_user.url_id, device) %>"><span class="editable"><%= device.name %></span> <i class="material-icons grey-text edit-button">mode_edit</i></a>
     </span>
     <div class="card-action">
       <div class="row">
@@ -17,7 +17,7 @@
             <% end %>
           </div>
           <div class="col s3">
-            <a class="modal-trigger valign-wrapper device-toggle" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%>&nbsp;Delay</a>
+            <a class="modal-trigger valign-wrapper device-toggle delayedButton" id='delayButton<%=device.id%>' data-tooltip='Delay Settings' href="#delay<%=device.id%>"><%= devices_delay_icon(device.delayed)%>&nbsp;Delay</a>
           </div>
         </div>
       </div>
@@ -34,7 +34,7 @@
             <% end %>
           </div>
           <div class="col s3">
-            <%= link_to user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'device-toggle valign-wrapper', data: { published: device.published? } } do %>
+            <%= link_to user_device_path(current_user.url_id, device.id, published: device.published), { method: :put, id:"publishedButton#{device.id}", remote: true, class: 'device-toggle valign-wrapper sharedButton', data: { published: device.published? } } do %>
               <%=devices_shared_icon(device)%>&nbsp;Sharing
             <% end %>
           </div>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -17,9 +17,13 @@
 
         <div id="perm<%=device.id%>" class="modal">
           <div class="modal-content">
-              <h4 id='<%=device.id%>-status'><%=device.name%> 
-              <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
-              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
+            <div>
+              <h4 class="device-name" id='<%=device.id%>-status'><%=device.name%> 
+                <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
+              </h4>
+              <%= devices_cloaked_info(device.cloaked) %>
+              <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a>
+            </div>
             <ul class="permissions collection" data-device=<%=device.id%>>
               <li class="collection-item row valign-wrapper  master-permissions">
                 <div class='valign col s6'>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -26,7 +26,7 @@
       <div class="row">
         <div class="col s12">
           <div class="col s6">
-            <a class="permissions-trigger btn-flat device-button" href="#perm<%=device.id%>" data-device=<%=device.id%>>
+            <a class="permissions-trigger btn-flat device-button" href="#perm<%=device.id%>" data-id=<%=device.id%>>
               <i class="material-icons right">lock</i>Permissions</a>
             </a>
           </div>
@@ -70,7 +70,7 @@
       <%= devices_cloaked_info(device.cloaked) %>
       <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a>
     </div>
-    <ul class="permissions collection" data-device=<%=device.id%>>
+    <ul class="permissions collection" data-id=<%=device.id%>>
       <li class="collection-item row valign-wrapper  master-permissions">
         <div class='valign col s6'>
           <h5>Update all permissions </h5>

--- a/app/views/users/devices/_device.html.erb
+++ b/app/views/users/devices/_device.html.erb
@@ -16,7 +16,8 @@
 
           <div id="perm<%=device.id%>" class="modal">
             <div class="modal-content">
-                <h4><%=device.name%> permissions <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %>
+                <h4><%=device.name%> permissions 
+                <%= fogged_icon(device.fogged) %> <%= devices_delay_icon(device.delayed) %> <%= devices_cloaked_icon(device.cloaked) %> <%= devices_shared_icon(device) %>
                 <a class="right tooltipped" target="_blank" data-tooltip='Permissions help' href="/help#permissions"><i class="material-icons">help</i></a></h4>
               <ul class="permissions collection" data-device=<%=device.id%>>
                 <li class="collection-item row valign-wrapper  master-permissions">

--- a/app/views/users/devices/update.js.erb
+++ b/app/views/users/devices/update.js.erb
@@ -32,9 +32,7 @@ var delayIcon = $('.delayIcon<%=@device.id%>');
 delayIcon.html("<%=j devices_delay_icon(@device.delayed) if @device.delayed %>");
 
 var deviceStatus = $('#<%=@device.id%>-status');
-deviceStatus.html('<h5>Master permissions <%= fogged_icon(@device.fogged) %> \
-                    <%= devices_delay_icon(@device.delayed) %></h5> \
-                    This device is <%= @device.fogged ? "fogged" : "not fogged" %> \
-                    and is <%= @device.delayed ? "delayed by #{@device.delayed} minutes" : "not delayed" %>.')
+deviceStatus.html('<%=@device.name%> permissions \
+                <%= fogged_icon(@device.fogged) %> <%= devices_delay_icon(@device.delayed) %> <%= devices_cloaked_icon(@device.cloaked) %> <%= devices_shared_icon(@device) %>')
 
 initPage();

--- a/app/views/users/devices/update.js.erb
+++ b/app/views/users/devices/update.js.erb
@@ -25,12 +25,6 @@ cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>&nbsp;Cloaking");
 var link = $('#sharedLink<%=@device.id%>');
 link.html("<%=j devices_shared_link(@device)%>");
 
-var fogIcon = $('.fogIcon<%=@device.id%>');
-fogIcon.html("<%=j fogged_icon(@device.fogged) if @device.fogged %>");
-
-var delayIcon = $('.delayIcon<%=@device.id%>');
-delayIcon.html("<%=j devices_delay_icon(@device.delayed) if @device.delayed %>");
-
 var deviceStatus = $('#<%=@device.id%>-status');
 deviceStatus.html('<%=@device.name%> permissions \
                 <%= fogged_icon(@device.fogged) %> <%= devices_delay_icon(@device.delayed) %> <%= devices_cloaked_icon(@device.cloaked) %> <%= devices_shared_icon(@device) %>')

--- a/app/views/users/devices/update.js.erb
+++ b/app/views/users/devices/update.js.erb
@@ -1,6 +1,6 @@
 <%= raw render_flash %>
 var fog = $('#fogButton<%=@device.id%>');
-fog.html("<%=j fogged_icon(@device.fogged)%>");
+fog.html("<%=j fogged_icon(@device.fogged)%>Fogging");
 <% if @device.fogged %>
   fog.data('confirm', 'Are you sure? Turning off fogging will allow your friends/apps to see your precise location')
 <% else %>
@@ -8,14 +8,14 @@ fog.html("<%=j fogged_icon(@device.fogged)%>");
 <% end %>
 
 var delay = $('#delayButton<%=@device.id%>');
-delay.html("<%=j devices_delay_icon(@device.delayed)%>");
+delay.html("<%=j devices_delay_icon(@device.delayed)%>Delay");
 $('#mins').val('<%= @device.delayed %>');
 
 var publish = $('#publishedButton<%=@device.id%>');
-publish.html("<%=j devices_shared_icon(@device)%>");
+publish.html("<%=j devices_shared_icon(@device)%>Sharing");
 
 var cloak = $('#cloakedButton<%=@device.id%>');
-cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>");
+cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>Cloaking");
 <% if @device.cloaked %>
   cloak.removeData('confirm').removeAttr('data-confirm')
 <% else %>

--- a/app/views/users/devices/update.js.erb
+++ b/app/views/users/devices/update.js.erb
@@ -14,6 +14,14 @@ $('#mins').val('<%= @device.delayed %>');
 var publish = $('#publishedButton<%=@device.id%>');
 publish.html("<%=j devices_shared_icon(@device)%>");
 
+var cloak = $('#cloakedButton<%=@device.id%>');
+cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>");
+<% if @device.cloaked %>
+  cloak.removeData('confirm').removeAttr('data-confirm')
+<% else %>
+  cloak.data('confirm', "Are you sure? Cloaking a device will hide it and all of it's check-ins from all of your apps and friends")
+<% end %>
+
 var link = $('#sharedLink<%=@device.id%>');
 link.html("<%=j devices_shared_link(@device)%>");
 

--- a/app/views/users/devices/update.js.erb
+++ b/app/views/users/devices/update.js.erb
@@ -1,6 +1,6 @@
 <%= raw render_flash %>
 var fog = $('#fogButton<%=@device.id%>');
-fog.html("<%=j fogged_icon(@device.fogged)%>Fogging");
+fog.html("<%=j fogged_icon(@device.fogged)%>&nbsp;Fogging");
 <% if @device.fogged %>
   fog.data('confirm', 'Are you sure? Turning off fogging will allow your friends/apps to see your precise location')
 <% else %>
@@ -8,14 +8,14 @@ fog.html("<%=j fogged_icon(@device.fogged)%>Fogging");
 <% end %>
 
 var delay = $('#delayButton<%=@device.id%>');
-delay.html("<%=j devices_delay_icon(@device.delayed)%>Delay");
+delay.html("<%=j devices_delay_icon(@device.delayed)%>&nbsp;Delay");
 $('#mins').val('<%= @device.delayed %>');
 
 var publish = $('#publishedButton<%=@device.id%>');
-publish.html("<%=j devices_shared_icon(@device)%>Sharing");
+publish.html("<%=j devices_shared_icon(@device)%>&nbsp;Sharing");
 
 var cloak = $('#cloakedButton<%=@device.id%>');
-cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>Cloaking");
+cloak.html("<%=j devices_cloaked_icon(@device.cloaked)%>&nbsp;Cloaking");
 <% if @device.cloaked %>
   cloak.removeData('confirm').removeAttr('data-confirm')
 <% else %>

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -1,4 +1,5 @@
 <div class="col s6 permission<%=permissions_control_class(permissionable)%>">
+  <label>Check-in history access</label>
   <div class='row'>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
       <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), class: 'with-gap', id: permissions_label_id(permissionable, 'disallowed') %>
@@ -14,17 +15,15 @@
     </div>
   </div>
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="bypass_fogging" data-switchtype="bypass_fogging">
-    <label id="<%=permissions_label_id(permissionable, 'bypass-fogging')%>">
-      <%= check_box_tag 'bypass_fogging','', permissions_check_box_value(permissionable, 'bypass_fogging') %>
-      <span class="lever"></span>
-      Bypass Fogging<%= permissions_for_all(permissionable) %>
+    <%= check_box_tag permissions_label_id(permissionable, 'bypass-fogging'),'', permissions_check_box_value(permissionable, 'bypass_fogging') %>
+    <label id="<%=permissions_label_id(permissionable, 'bypass-fogging')%>" for="<%=permissions_label_id(permissionable, 'bypass-fogging')%>">
+      Bypass Fogging
     </label>
   </div>
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="bypass_delay" data-switchtype="bypass_delay">
-    <label id="<%=permissions_label_id(permissionable, 'bypass-delay')%>">
-      <%= check_box_tag 'bypass_delay','', permissions_check_box_value(permissionable, 'bypass_delay') %>
-      <span class="lever"></span>
-      Bypass Delay<%= permissions_for_all(permissionable) %>
+    <%= check_box_tag permissions_label_id(permissionable, 'bypass-delay'),'', permissions_check_box_value(permissionable, 'bypass_delay') %>
+    <label id="<%=permissions_label_id(permissionable, 'bypass-delay')%>" for="<%=permissions_label_id(permissionable, 'bypass-delay')%>">
+      Bypass Delay
     </label>
   </div>
 </div>

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -1,11 +1,25 @@
 <div class="col s5 permission<%=permissions_control_class(permissionable)%>">
-  <div class="<%=permissions_switch_class(permissionable)%> switch" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
+  <div class='row'>
+    <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
+      <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), id: permissions_label_id(permissionable, 'disallowed') %>
+      <label id="<%=permissions_label_id(permissionable, 'disallowed')%>" for="<%=permissions_label_id(permissionable, 'disallowed')%>">Disable <%= permissions_for_all(permissionable)%></label>
+    </div>
+    <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
+      <%= radio_button_tag permissionable.id, 'last_only', permissions_check_box_value(permissionable, 'last_only'), id: permissions_label_id(permissionable, 'last_only') %>
+      <label id="<%=permissions_label_id(permissionable, 'last_only')%>" for="<%=permissions_label_id(permissionable, 'last_only')%>">Last <%= permissions_for_all(permissionable)%></label>
+    </div>
+    <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="complete">
+      <%= radio_button_tag permissionable.id, 'complete', permissions_check_box_value(permissionable, 'complete'), id: permissions_label_id(permissionable, 'complete')  %>
+      <label id="<%=permissions_label_id(permissionable, 'complete')%>" for="<%=permissions_label_id(permissionable, 'complete')%>">Full history <%= permissions_for_all(permissionable)%></label>
+    </div>
+  </div>
+  <!-- <div class="<%=permissions_switch_class(permissionable)%> switch" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
     <label id="<%=permissions_label_id(permissionable, 'disallowed')%>">
       <%= check_box_tag 'privilege','', permissions_check_box_value(permissionable, 'disallowed') %>
       <span class="lever"></span>
       Disable access<%= permissions_for_all(permissionable) %>
     </label>
-  </div>
+  </div> -->
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="bypass_fogging" data-switchtype="bypass_fogging">
     <label id="<%=permissions_label_id(permissionable, 'bypass-fogging')%>">
       <%= check_box_tag 'bypass_fogging','', permissions_check_box_value(permissionable, 'bypass_fogging') %>
@@ -20,11 +34,12 @@
       Bypass Delay<%= permissions_for_all(permissionable) %>
     </label>
   </div>
-  <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
+  <!-- <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
     <label id="<%=permissions_label_id(permissionable, 'last-only')%>">
       <%= check_box_tag 'last_only','', permissions_check_box_value(permissionable, 'complete') %>
       <span class="lever"></span>
       Last checkin only/Full history<%= permissions_for_all(permissionable) %>
     </label>
-  </div>
+  </div> -->
 </div>
+

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -1,25 +1,18 @@
 <div class="col s5 permission<%=permissions_control_class(permissionable)%>">
   <div class='row'>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
-      <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), id: permissions_label_id(permissionable, 'disallowed') %>
+      <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), class: 'with-gap', id: permissions_label_id(permissionable, 'disallowed') %>
       <label id="<%=permissions_label_id(permissionable, 'disallowed')%>" for="<%=permissions_label_id(permissionable, 'disallowed')%>">Disable <%= permissions_for_all(permissionable)%></label>
     </div>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
-      <%= radio_button_tag permissionable.id, 'last_only', permissions_check_box_value(permissionable, 'last_only'), id: permissions_label_id(permissionable, 'last_only') %>
+      <%= radio_button_tag permissionable.id, 'last_only', permissions_check_box_value(permissionable, 'last_only'), class: 'with-gap', id: permissions_label_id(permissionable, 'last_only') %>
       <label id="<%=permissions_label_id(permissionable, 'last_only')%>" for="<%=permissions_label_id(permissionable, 'last_only')%>">Last <%= permissions_for_all(permissionable)%></label>
     </div>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="complete">
-      <%= radio_button_tag permissionable.id, 'complete', permissions_check_box_value(permissionable, 'complete'), id: permissions_label_id(permissionable, 'complete')  %>
+      <%= radio_button_tag permissionable.id, 'complete', permissions_check_box_value(permissionable, 'complete'), class: 'with-gap', id: permissions_label_id(permissionable, 'complete')  %>
       <label id="<%=permissions_label_id(permissionable, 'complete')%>" for="<%=permissions_label_id(permissionable, 'complete')%>">Full history <%= permissions_for_all(permissionable)%></label>
     </div>
   </div>
-  <!-- <div class="<%=permissions_switch_class(permissionable)%> switch" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
-    <label id="<%=permissions_label_id(permissionable, 'disallowed')%>">
-      <%= check_box_tag 'privilege','', permissions_check_box_value(permissionable, 'disallowed') %>
-      <span class="lever"></span>
-      Disable access<%= permissions_for_all(permissionable) %>
-    </label>
-  </div> -->
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="bypass_fogging" data-switchtype="bypass_fogging">
     <label id="<%=permissions_label_id(permissionable, 'bypass-fogging')%>">
       <%= check_box_tag 'bypass_fogging','', permissions_check_box_value(permissionable, 'bypass_fogging') %>
@@ -34,12 +27,5 @@
       Bypass Delay<%= permissions_for_all(permissionable) %>
     </label>
   </div>
-  <!-- <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
-    <label id="<%=permissions_label_id(permissionable, 'last-only')%>">
-      <%= check_box_tag 'last_only','', permissions_check_box_value(permissionable, 'complete') %>
-      <span class="lever"></span>
-      Last checkin only/Full history<%= permissions_for_all(permissionable) %>
-    </label>
-  </div> -->
 </div>
 

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -3,15 +3,15 @@
   <div class='row'>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
       <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), class: 'with-gap', id: permissions_label_id(permissionable, 'disallowed') %>
-      <label id="<%=permissions_label_id(permissionable, 'disallowed')%>" for="<%=permissions_label_id(permissionable, 'disallowed')%>">Disable <%= permissions_for_all(permissionable)%></label>
+      <label id="<%=permissions_label_id(permissionable, 'disallowed')%>" for="<%=permissions_label_id(permissionable, 'disallowed')%>">Disable</label>
     </div>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="last_only">
       <%= radio_button_tag permissionable.id, 'last_only', permissions_check_box_value(permissionable, 'last_only'), class: 'with-gap', id: permissions_label_id(permissionable, 'last_only') %>
-      <label id="<%=permissions_label_id(permissionable, 'last_only')%>" for="<%=permissions_label_id(permissionable, 'last_only')%>">Last <%= permissions_for_all(permissionable)%></label>
+      <label id="<%=permissions_label_id(permissionable, 'last_only')%>" for="<%=permissions_label_id(permissionable, 'last_only')%>">Last</label>
     </div>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="complete">
       <%= radio_button_tag permissionable.id, 'complete', permissions_check_box_value(permissionable, 'complete'), class: 'with-gap', id: permissions_label_id(permissionable, 'complete')  %>
-      <label id="<%=permissions_label_id(permissionable, 'complete')%>" for="<%=permissions_label_id(permissionable, 'complete')%>">Full history <%= permissions_for_all(permissionable)%></label>
+      <label id="<%=permissions_label_id(permissionable, 'complete')%>" for="<%=permissions_label_id(permissionable, 'complete')%>">Full history</label>
     </div>
   </div>
   <div class="<%=permissions_switch_class(permissionable)%> switch disable" data-id=<%=permissionable.id%> data-attribute="bypass_fogging" data-switchtype="bypass_fogging">

--- a/app/views/users/permissions/_controls.html.erb
+++ b/app/views/users/permissions/_controls.html.erb
@@ -1,4 +1,4 @@
-<div class="col s5 permission<%=permissions_control_class(permissionable)%>">
+<div class="col s6 permission<%=permissions_control_class(permissionable)%>">
   <div class='row'>
     <div class="<%=permissions_switch_class(permissionable)%> radio col" data-id=<%=permissionable.id%> data-attribute="privilege" data-switchtype="disallowed">
       <%= radio_button_tag permissionable.id, 'disallowed', permissions_check_box_value(permissionable, 'disallowed'), class: 'with-gap', id: permissions_label_id(permissionable, 'disallowed') %>

--- a/app/views/users/permissions/index.js.erb
+++ b/app/views/users/permissions/index.js.erb
@@ -10,23 +10,12 @@ if($list.children().length===1) {
   $list.append(`
     <% @presenter.permissions.each_with_index do |permission, i| %>
       <li class="collection-item row valign-wrapper">
-        <div class='valign col s4'>
+        <div class='valign col s6'>
         <% if @presenter.device.present? %>
           <%= permissible_title(permission.permissible) %>
         <% else %>
           <%= permission.device.name %>
         <% end %>
-        </div>
-        <div class='col s2'>
-          <span id='fogIcon<%=permission.id%>' class='fogIcon<%=permission.device.id%> tipped' data-tooltip="<%=approvals_approvable_name(permission.permissible)%> can only see fogged data for this device">
-            <%= fogged_icon(permission.device.fogged) if permission.device.fogged %>
-          </span>
-          <span id='delayIcon<%=permission.id%>' class='delayIcon<%=permission.device.id%> tipped' data-tooltip="<%=approvals_approvable_name(permission.permissible)%> can only see your data after a delay for this device">
-            <%= devices_delay_icon(permission.device.delayed) if permission.device.delayed %>
-          </span>
-          <span id='accessIcon<%=permission.id%>' class='tipped' data-tooltip="<%=approvals_approvable_name(permission.permissible)%> can't see any data from this device">
-            <%= devices_access_icon  %>
-          </span>
         </div>
         <%= render partial: "users/permissions/controls", object: permission, as: 'permissionable' %>
       </li>

--- a/app/views/users/permissions/index.js.erb
+++ b/app/views/users/permissions/index.js.erb
@@ -10,7 +10,7 @@ if($list.children().length===1) {
   $list.append(`
     <% @presenter.permissions.each_with_index do |permission, i| %>
       <li class="collection-item row valign-wrapper">
-        <div class='valign col s5'>
+        <div class='valign col s4'>
         <% if @presenter.device.present? %>
           <%= permissible_title(permission.permissible) %>
         <% else %>

--- a/app/views/welcome/help.html.erb
+++ b/app/views/welcome/help.html.erb
@@ -18,7 +18,7 @@
     <div id="devices" class="section scrollspy">
       <h4> <i class="material-icons">devices</i> Devices</h4>
       <div id="fogging" class="section scrollspy">
-        <h5><i class="material-icons">cloud_done</i> Fogging</h5>
+        <h5><i class="material-icons">cloud</i> Fogging</h5>
         <p>
           Fogging allows you additional control over how much of your location data your data consumers (friends and apps) can see. Fogging a checkin or a device will mean that your data consumers will not be shown your exact location or coordinates, instead they will see a location usually localised to the nearest city/town or a randomised location within 50km of your actual location if there are no settlements nearby.</br></br>
           Fogging is enabled by default when you create a device. Whilst on, you can choose to allow certain friends or apps to see precise data by enabling bypass fogging via permissions.

--- a/app/views/welcome/help.html.erb
+++ b/app/views/welcome/help.html.erb
@@ -36,8 +36,14 @@
           Delay is not set when you first create a device. Once you have set a delay you can choose to allow certain friends or apps to see your data immediately by enabling bypass delay via permissions.
         </p>
       </div>
+      <div id="cloaking" class="section scrollspy">
+        <h5><i class="material-icons">visibility</i> Cloaking</h5>
+        <p>
+          Cloaking a device hides it and all of its check-ins from all of your friends and apps. It also disables the device's shared page if the device is shared.
+        </p>
+      </div>
       <div id="sharing" class="section scrollspy">
-        <h5><i class="material-icons">visibility</i> Sharing</h5>
+        <h5><i class="material-icons">public</i> Sharing</h5>
         <p>
           Sharing a device generates a publicly available page with this device's latest location. Fogging and delay still apply.
         </p>

--- a/db/migrate/20170120161207_add_cloaked_to_devices.rb
+++ b/db/migrate/20170120161207_add_cloaked_to_devices.rb
@@ -1,0 +1,5 @@
+class AddCloakedToDevices < ActiveRecord::Migration[5.0]
+  def change
+  	add_column :devices, :cloaked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119104140) do
+ActiveRecord::Schema.define(version: 20170120161207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170119104140) do
     t.integer "delayed"
     t.string  "alias"
     t.boolean "published", default: false
+    t.boolean "cloaked",   default: false
     t.index ["uuid"], name: "index_devices_on_uuid", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 20170119104140) do
   end
 
   create_table "attachinary_files", force: :cascade do |t|
-    t.integer  "attachinariable_id"
     t.string   "attachinariable_type"
+    t.integer  "attachinariable_id"
     t.string   "scope"
     t.string   "public_id"
     t.string   "version"

--- a/features/devices.feature
+++ b/features/devices.feature
@@ -31,7 +31,7 @@ Feature: Devices
           Then I should see "Device cloaking is on"
           And I should have a cloaked device
       When I click the link "cloud"
-        Then I should see a link that says "cloud_done"
+        Then I should see a link that says "cloud"
         And I should have an unfogged device
       When I click the link "timer"
       And I click the slider

--- a/features/devices.feature
+++ b/features/devices.feature
@@ -24,9 +24,12 @@ Feature: Devices
         When I enter UUID "123456789123" and a friendly name "G-RALA"
       And I click "Add"
       And I click the link "Devices"
-      When I click the link "visibility"
+      When I click the link "public"
         Then I should see "Location sharing is on"
         And I should have a published device
+        When I click the link "visibility"
+          Then I should see "Device cloaking is on"
+          And I should have a cloaked device
       When I click the link "cloud"
         Then I should see a link that says "cloud_done"
         And I should have an unfogged device

--- a/features/map.feature
+++ b/features/map.feature
@@ -28,6 +28,6 @@ Feature: map
       Given I right click on the map
         And I click "Create checkin here"
       When I click the link "Devices"
-        And I click the link "visibility"
+        And I click the link "public"
       When I visit my device published page
        Then I have 1 checkins on the map

--- a/features/step_definitions/devices_steps.rb
+++ b/features/step_definitions/devices_steps.rb
@@ -31,6 +31,10 @@ Then(/^I should have a published device$/) do
   expect(page).not_to have_selector('a[data-tooltip="Device sharing"] i.disabled-icon')
 end
 
+Then(/^I should have a cloaked device$/) do
+  expect(page).not_to have_selector('a[data-tooltip="Cloaking"] i.disabled-icon-simple')
+end
+
 Then(/^I should have a delayed device$/) do
   expect(page).not_to have_selector('a.modal-trigger i.disabled-icon')
 end

--- a/features/step_definitions/devices_steps.rb
+++ b/features/step_definitions/devices_steps.rb
@@ -24,19 +24,19 @@ Then(/^I should not have a device$/) do
 end
 
 Then(/^I should have an unfogged device$/) do
-  expect(page).to have_selector('a[data-tooltip="Fogging"] i.disabled-icon', count: 1)
+  expect(page).to have_selector('a.fogButton i.disabled-icon', count: 1)
 end
 
 Then(/^I should have a published device$/) do
-  expect(page).not_to have_selector('a[data-tooltip="Device sharing"] i.disabled-icon')
+  expect(page).not_to have_selector('a.sharedButton i.disabled-icon')
 end
 
 Then(/^I should have a cloaked device$/) do
-  expect(page).not_to have_selector('a[data-tooltip="Cloaking"] i.disabled-icon')
+  expect(page).not_to have_selector('a.cloakedButton i.disabled-icon')
 end
 
 Then(/^I should have a delayed device$/) do
-  expect(page).not_to have_selector('a.modal-trigger i.disabled-icon')
+  expect(page).not_to have_selector('a.delayedButton i.disabled-icon')
 end
 
 Given(/^I click the slider$/) do

--- a/features/step_definitions/devices_steps.rb
+++ b/features/step_definitions/devices_steps.rb
@@ -32,7 +32,7 @@ Then(/^I should have a published device$/) do
 end
 
 Then(/^I should have a cloaked device$/) do
-  expect(page).not_to have_selector('a[data-tooltip="Cloaking"] i.disabled-icon-simple')
+  expect(page).not_to have_selector('a[data-tooltip="Cloaking"] i.disabled-icon')
 end
 
 Then(/^I should have a delayed device$/) do

--- a/features/step_definitions/devices_steps.rb
+++ b/features/step_definitions/devices_steps.rb
@@ -16,11 +16,11 @@ Given(/^I enter UUID "(.*?)" and a friendly name "(.*?)"$/) do |uuid, device_nam
 end
 
 Then(/^I should have a device$/) do
-  expect(page).to have_selector('div.card-panel', count: 1)
+  expect(page).to have_selector('div.card', count: 1)
 end
 
 Then(/^I should not have a device$/) do
-  expect(page).not_to have_selector('div.card-panel')
+  expect(page).not_to have_selector('div.card')
 end
 
 Then(/^I should have an unfogged device$/) do

--- a/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
+++ b/spec/controllers/api/v1/users/checkins_controller_privilege_spec.rb
@@ -27,9 +27,16 @@ RSpec.describe Api::V1::CheckinsController, type: :controller do
 
   context 'with 3 checkins: 2 old, 1 new, on 2 devices' do
     describe 'GET #last/#index' do
-      context 'with privilege set to disallowed and bypass_delay set to false' do
+      context 'with device cloaked' do
         it 'should return 0 checkins' do
           # call_checkin_action(method, no. of checkins returned, first checkin)
+          Device.all.each { |device| device.update! cloaked: true }
+          %w(last index).each { |method| call_checkin_action(method, 0, nil) }
+        end
+      end
+
+      context 'with privilege set to disallowed and bypass_delay set to false' do
+        it 'should return 0 checkins' do
           Device.all.each { |device| update_permissions(device, 'disallowed', false) }
           %w(last index).each { |method| call_checkin_action(method, 0, nil) }
         end

--- a/spec/controllers/api/v1/users/devices_controller_spec.rb
+++ b/spec/controllers/api/v1/users/devices_controller_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Api::V1::Users::DevicesController, type: :controller do
       expect(res_hash.first['id']).to be device.id
     end
 
+    it 'should not return friends cloaked devices' do
+      second_user.devices.each{ |device| device.update! cloaked: true }
+      get :index, params: params.merge(user_id: second_user.id)
+      expect(res_hash.size).to eq 0
+    end
+
     it 'should record the request' do
       expect(developer.requests.count).to be 0
       get :index, params: params

--- a/spec/controllers/users/dashboards_controller_spec.rb
+++ b/spec/controllers/users/dashboards_controller_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Users::DashboardsController, type: :controller do
       end
     end
 
+    context 'device cloaked' do
+      it 'should render no checkins' do
+        friend_device.update! cloaked: true
+        get :show, params: { user_id: user.id }
+        expect((assigns :presenter).gon[:friends][0][:lastCheckin]).to be nil
+      end
+    end
+
     context 'permission complete, bypass delay false, bypass fogging false' do
       it 'should render one historic fogged checkin' do
         friend_device.permission_for(user).update! privilege: 'complete', bypass_delay: false, bypass_fogging: false

--- a/spec/controllers/users/devices_controller_spec.rb
+++ b/spec/controllers/users/devices_controller_spec.rb
@@ -88,10 +88,13 @@ RSpec.describe Users::DevicesController, type: :controller do
   end
 
   describe 'GET #shared' do
-    it 'should deny access if device not published' do
+    it 'should deny access if device not published or cloaked' do
       get :shared, params: params
       expect(response).to redirect_to(root_path)
-      expect(flash[:notice]).to match('not shared')
+      expect(flash[:notice]).to match('Could not find ')
+      device.update! published: true, cloaked: true
+      get :shared, params: params
+      expect(response).to redirect_to(root_path)
     end
 
     it 'should render page if published and checkin should be fogged' do

--- a/spec/controllers/users/devices_controller_spec.rb
+++ b/spec/controllers/users/devices_controller_spec.rb
@@ -232,6 +232,15 @@ RSpec.describe Users::DevicesController, type: :controller do
       expect(device.reload.name).to_not eq 'Computer'
       expect(response.body).to match 'already been taken'
     end
+
+    it 'should switch cloaked status' do
+      expect(device.cloaked?).to be false
+      request.accept = 'text/javascript'
+      put :update, params: params.merge(cloaked: true)
+      expect(flash[:notice]).to match 'Device cloaking is'
+      device.reload
+      expect(device.cloaked?).to be true
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/controllers/users/friends_controller_spec.rb
+++ b/spec/controllers/users/friends_controller_spec.rb
@@ -87,10 +87,10 @@ RSpec.describe Users::FriendsController, type: :controller do
     end
 
     context 'device cloaked' do
-      it 'should render no checkins' do
+      it 'should fail to render' do
         device.update! cloaked: true
         get :show_device, params: params
-        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 0
+        expect(assigns :presenter).to eq nil
       end
     end
 

--- a/spec/controllers/users/friends_controller_spec.rb
+++ b/spec/controllers/users/friends_controller_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Users::FriendsController, type: :controller do
       end
     end
 
+    context 'device cloaked' do
+      it 'should render no checkins' do
+        device.update! cloaked: true
+        get :show, params: params
+        expect((assigns :presenter).index_gon[:checkins].size).to eq 0
+      end
+    end
+
     context 'permission complete, bypass delay false, bypass fogging false' do
       it 'should render one historic fogged checkin' do
         device.permission_for(user).update! privilege: 'complete', bypass_delay: false, bypass_fogging: false
@@ -73,6 +81,14 @@ RSpec.describe Users::FriendsController, type: :controller do
     context 'permission disallowed' do
       it 'should render no checkins' do
         device.permission_for(user).update! privilege: 'disallowed'
+        get :show_device, params: params
+        expect((assigns :presenter).show_device_gon[:checkins].size).to eq 0
+      end
+    end
+
+    context 'device cloaked' do
+      it 'should render no checkins' do
+        device.update! cloaked: true
         get :show_device, params: params
         expect((assigns :presenter).show_device_gon[:checkins].size).to eq 0
       end

--- a/spec/helpers/permissions_helper_spec.rb
+++ b/spec/helpers/permissions_helper_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PermissionsHelper, type: :helper do
   describe '#permissions_label_id' do
     it 'should return the permissionable id and switch type if a Permission' do
       expect(helper.permissions_label_id(permission, 'disallowed')).to include(permission.id.to_s)
-      expect(helper.permissions_label_id(developer, 'disallowed')).to be(nil)
+      expect(helper.permissions_label_id(developer, 'disallowed')).to include('master')
     end
   end
 

--- a/spec/helpers/permissions_helper_spec.rb
+++ b/spec/helpers/permissions_helper_spec.rb
@@ -27,15 +27,6 @@ RSpec.describe PermissionsHelper, type: :helper do
     end
   end
 
-  describe '#permissions_for_all' do
-    it 'should return a string if permissionable is not a Permission' do
-      expect(helper.permissions_for_all(developer)).to be_a(String)
-    end
-    it 'should not return anything if permissionable is a Permission' do
-      expect(helper.permissions_for_all(permission)).to be_nil
-    end
-  end
-
   describe '#permissions_control_class' do
     it 'should return a string with the permissionable id' do
       expect(helper.permissions_control_class(developer)).to include(developer.id.to_s)


### PR DESCRIPTION
Added the ability to cloak devices which hides the device from your friends and apps, also hides all of it's checkins. Also will behave as if not shared if it has been shared.

Also overhauled look of cards on devices page and using checkboxes + radiobuttons inside permissions modal instead of four switches. 

(permissions modal is also on friends/apps page)