### PR TITLE
fogged-output

### DIFF
--- a/app/models/checkin.rb
+++ b/app/models/checkin.rb
@@ -47,11 +47,7 @@ class Checkin < ApplicationRecord
   end
 
   def update_output
-    if fogged || device.fogged
-      assign_output_to_fogged
-    else
-      assign_output_to_unfogged
-    end
+    fogged ? assign_output_to_fogged : assign_output_to_unfogged
   end
 
   def assign_output_to_fogged
@@ -91,7 +87,6 @@ class Checkin < ApplicationRecord
 
   def switch_fog
     update(fogged: !fogged)
-    return if device.fogged
     update_output
     save
   end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -50,6 +50,10 @@ class Device < ApplicationRecord
     if can_bypass_fogging?(permissible)
       sanitized.select(:id, :created_at, :updated_at, :device_id, :lat,
                        :lng, :address, :city, :postal_code, :country_code)
+    elsif fogged
+      sanitized.select('id', 'created_at', 'updated_at', 'device_id', 'fogged_lat AS lat', 'fogged_lng AS lng',
+                       'fogged_city AS address', 'fogged_city AS city', 'fogged_country_code AS postal_code',
+                       'fogged_country_code AS country_code')
     else
       sanitized.select('id', 'created_at', 'updated_at', 'device_id', 'output_lat AS lat', 'output_lng AS lng',
                        'output_address AS address', 'output_city AS city', 'output_postal_code AS postal_code',

--- a/app/presenters/users/devices_presenter.rb
+++ b/app/presenters/users/devices_presenter.rb
@@ -75,10 +75,16 @@ module Users
     end
 
     def gon_shared_checkin
-      Checkin.where(id: @checkin.id)
-             .select('id', 'created_at', 'updated_at', 'device_id', 'output_lat AS lat', 'output_lng AS lng',
-                     'output_address AS address', 'output_city AS city', 'output_postal_code AS postal_code',
-                     'output_country_code AS country_code')[0]
+      checkin = Checkin.where(id: @checkin.id)
+      if @checkin.device.fogged?
+        checkin.select('id', 'created_at', 'updated_at', 'device_id', 'fogged_lat AS lat', 'fogged_lng AS lng',
+                       'fogged_city AS address', 'fogged_city AS city', 'fogged_country_code AS postal_code',
+                       'fogged_country_code AS country_code')[0]
+      else
+        checkin.select('id', 'created_at', 'updated_at', 'device_id', 'output_lat AS lat', 'output_lng AS lng',
+                       'output_address AS address', 'output_city AS city', 'output_postal_code AS postal_code',
+                       'output_country_code AS country_code')[0]
+      end
     end
 
     def show_checkins


### PR DESCRIPTION
making sure actual info is shown if bypass fogging enabled (not applicable on shared page), fogged info is shown if device is fogged, if not then output info used