### PR TITLE
Device show page buttons 5667

### DIFF
--- a/app/assets/stylesheets/devices-show.scss.erb
+++ b/app/assets/stylesheets/devices-show.scss.erb
@@ -94,10 +94,11 @@
 
   .buttons {
     margin: 10px;
+    margin-top: 30px;
     display: flex;
     justify-content: space-around;
-    margin-left: 15%;
-    margin-right: 15%;
+    margin-left: 25%;
+    margin-right: 25%;
   }
 
   .disabled-icon {

--- a/app/assets/stylesheets/devices-show.scss.erb
+++ b/app/assets/stylesheets/devices-show.scss.erb
@@ -92,6 +92,11 @@
     margin: 0;
   }
 
+  .delete-buttons {
+    display: flex;
+    justify-content: space-around;
+  }
+
   .buttons {
     margin: 10px;
     margin-top: 30px;
@@ -99,6 +104,16 @@
     justify-content: space-around;
     margin-left: 25%;
     margin-right: 25%;
+    @media screen and (max-width: 800px){
+      margin-left: 5%;
+      margin-right: 5%;
+    }
+    @media screen and (max-width: 500px){
+      .modal-trigger {
+        padding: 0 1rem;
+        font-size: 10px;
+      }
+    }
   }
 
   .disabled-icon {

--- a/app/views/users/devices/show.html.slim
+++ b/app/views/users/devices/show.html.slim
@@ -33,15 +33,16 @@
             | Currently, you are filtering to only see check-ins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}.
           - else
             | Currently, you are seeing all check-ins for this device.
-        .delete-buttons
-          = link_to "Delete all check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id), { method: :delete, class: "btn red white-text", data: { confirm: "Delete all checkins for this device?" } }
-          - if @device_show_presenter.date_range[:from]
-            = link_to "Delete visible check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id, from: @device_show_presenter.date_range[:from], to: @device_show_presenter.date_range[:to]), { method: :delete, class: "btn red white-text", data: { confirm: "Delete checkins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}?" } }
+        = link_to "Delete all check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id), { method: :delete, class: "btn red white-text", data: { confirm: "Delete all checkins for this device?" } }
+        - if @device_show_presenter.date_range[:from]
+          br
+          br
+          = link_to "Delete visible check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id, from: @device_show_presenter.date_range[:from], to: @device_show_presenter.date_range[:to]), { method: :delete, class: "btn red white-text", data: { confirm: "Delete checkins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}?" } }
       br
       h4.center-align Delete device
       .center-align
         p.center-align
-          | Delete entire device. You will no longer be able to create check-ins with this device.
+          | You will no longer be able to create check-ins with this device.
         = link_to "Delete device", user_device_path(current_user.url_id, @device_show_presenter.device), { method: :delete, class: "btn red white-text", data: { confirm: "Are you sure?" } }
   /! templates
   script#markerPopupTmpl type="x-tmpl-mustache" 

--- a/app/views/users/devices/show.html.slim
+++ b/app/views/users/devices/show.html.slim
@@ -3,11 +3,11 @@
   .bottom-panel.valign-wrapper
     .buttons
       a.modal-trigger.btn.red.white-text href="#delete#{@device_show_presenter.device.id}" id="deleteButton#{@device_show_presenter.device.id}" 
-        | Delete
+        | Delete...
       a.modal-trigger.btn.blue.white-text href="#checkin#{@device_show_presenter.device.id}" id="checkinButton#{@device_show_presenter.device.id}"
-        | Checkin
+        | Check-in
       a.modal-trigger.btn.green.white-text.downloadButton data-tooltip=("Download range") href="#download#{@device_show_presenter.device.id}" id="downloadButton#{@device_show_presenter.device.id}"
-        | Download checkins
+        | Download
 
   .modal.checkin-modal id="checkin#{@device_show_presenter.device.id}"
     .modal-content
@@ -16,6 +16,8 @@
         p.center-align
           | You're going to check-in now
         a#checkinNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now
+        br
+        br
         a#checkinFoggedNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now (fogged)
 
   .modal.delete-modal id="delete#{@device_show_presenter.device.id}"

--- a/app/views/users/devices/show.html.slim
+++ b/app/views/users/devices/show.html.slim
@@ -33,9 +33,10 @@
             | Currently, you are filtering to only see check-ins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}.
           - else
             | Currently, you are seeing all check-ins for this device.
-        = link_to "Delete all check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id), { method: :delete, class: "btn red white-text", data: { confirm: "Delete all checkins for this device?" } }
-        - if @device_show_presenter.date_range[:from]
-          = link_to "Delete visible check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id, from: @device_show_presenter.date_range[:from], to: @device_show_presenter.date_range[:to]), { method: :delete, class: "btn red white-text", data: { confirm: "Delete checkins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}?" } }
+        .delete-buttons
+          = link_to "Delete all check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id), { method: :delete, class: "btn red white-text", data: { confirm: "Delete all checkins for this device?" } }
+          - if @device_show_presenter.date_range[:from]
+            = link_to "Delete visible check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id, from: @device_show_presenter.date_range[:from], to: @device_show_presenter.date_range[:to]), { method: :delete, class: "btn red white-text", data: { confirm: "Delete checkins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}?" } }
       br
       h4.center-align Delete device
       .center-align

--- a/app/views/users/devices/show.html.slim
+++ b/app/views/users/devices/show.html.slim
@@ -5,12 +5,21 @@
       a.modal-trigger.btn.red.white-text href="#delete#{@device_show_presenter.device.id}" id="deleteButton#{@device_show_presenter.device.id}" 
         | Delete check-ins
       = link_to "Delete device", user_device_path(current_user.url_id, @device_show_presenter.device), { method: :delete, class: "btn red white-text", data: { confirm: "Are you sure?" } }
-      a#checkinNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now
-      a#checkinFoggedNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now (fogged)
-    .buttons
+      a.modal-trigger.btn.blue.white-text href="#checkin#{@device_show_presenter.device.id}" id="checkinButton#{@device_show_presenter.device.id}"
+        | Checkin
       a.modal-trigger.btn.green.white-text.downloadButton data-tooltip=("Download range") href="#download#{@device_show_presenter.device.id}" id="downloadButton#{@device_show_presenter.device.id}"
         | Download checkins
-  .modal.delete-modal id="delete#{@device_show_presenter.device.id}" 
+
+  .modal.checkin-modal id="checkin#{@device_show_presenter.device.id}"
+    .modal-content
+      h4.center-align Checkin
+      .center-align
+        p.center-align
+          | You're going to check-in now
+        a#checkinNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now
+        a#checkinFoggedNow.btn.blue.white-text data-turbolinks="false" href="#" Checkin now (fogged)
+
+  .modal.delete-modal id="delete#{@device_show_presenter.device.id}"
     .modal-content
       h4.center-align Delete checkins
       .center-align

--- a/app/views/users/devices/show.html.slim
+++ b/app/views/users/devices/show.html.slim
@@ -3,8 +3,7 @@
   .bottom-panel.valign-wrapper
     .buttons
       a.modal-trigger.btn.red.white-text href="#delete#{@device_show_presenter.device.id}" id="deleteButton#{@device_show_presenter.device.id}" 
-        | Delete check-ins
-      = link_to "Delete device", user_device_path(current_user.url_id, @device_show_presenter.device), { method: :delete, class: "btn red white-text", data: { confirm: "Are you sure?" } }
+        | Delete
       a.modal-trigger.btn.blue.white-text href="#checkin#{@device_show_presenter.device.id}" id="checkinButton#{@device_show_presenter.device.id}"
         | Checkin
       a.modal-trigger.btn.green.white-text.downloadButton data-tooltip=("Download range") href="#download#{@device_show_presenter.device.id}" id="downloadButton#{@device_show_presenter.device.id}"
@@ -35,6 +34,12 @@
         = link_to "Delete all check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id), { method: :delete, class: "btn red white-text", data: { confirm: "Delete all checkins for this device?" } }
         - if @device_show_presenter.date_range[:from]
           = link_to "Delete visible check-ins", user_device_checkins_path(current_user.url_id, @device_show_presenter.device.id, from: @device_show_presenter.date_range[:from], to: @device_show_presenter.date_range[:to]), { method: :delete, class: "btn red white-text", data: { confirm: "Delete checkins from #{humanize_date(@device_show_presenter.date_range[:from])} to #{humanize_date(@device_show_presenter.date_range[:to])}?" } }
+      br
+      h4.center-align Delete device
+      .center-align
+        p.center-align
+          | Delete entire device. You will no longer be able to create check-ins with this device.
+        = link_to "Delete device", user_device_path(current_user.url_id, @device_show_presenter.device), { method: :delete, class: "btn red white-text", data: { confirm: "Are you sure?" } }
   /! templates
   script#markerPopupTmpl type="x-tmpl-mustache" 
     h3 

--- a/spec/features/checkins_spec.rb
+++ b/spec/features/checkins_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Checkins", type: :feature do
   end
 
   def and_i_click_delete_checkins
-    click_on "Delete check-ins"
+    click_on "Delete"
   end
 
   def and_i_click_delete_all


### PR DESCRIPTION
According to: https://redmine.smartdata.solutions/issues/5667

Popups now look like:
![checkin](https://monosnap.com/file/I8Yql2o2DLELc1xBNCDrdHcwZ6ReBZ.png)
![delete](https://monosnap.com/file/1Orc5dioGexfF56dURheX9SqSMUH1G.png)

This is how show page looks like:
![show](https://monosnap.com/file/mfd7U5Ep37AfZRoZF3ou6g8sgB0WMu.png)

So buttons again are in one row. But copyright text is overlapping from the right side.