### PR TITLE
approvals-destroy-7193

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,7 @@ class User < ApplicationRecord
   def create_pending_requests
     EmailRequest.where(email: email).find_each do |request|
       Approval.add_friend(request.user, self)
+      request.destroy
     end
   end
 


### PR DESCRIPTION
destroying email requests once the pending request has been created